### PR TITLE
Move MockAgent command initialization to constructor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ language: java
 jdk:
   - oraclejdk8
 install: true
+before_script:
+  - unset _JAVA_OPTIONS
 script: mvn -B clean verify -Dgpg.skip
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/xmvn-core/src/main/java/org/fedoraproject/xmvn/resolver/impl/MockAgent.java
+++ b/xmvn-core/src/main/java/org/fedoraproject/xmvn/resolver/impl/MockAgent.java
@@ -25,23 +25,24 @@ import org.fedoraproject.xmvn.logging.impl.Logger;
  */
 class MockAgent
 {
-    private static final String REQUEST_CMD = System.getProperty( "xmvn.resolver.requestArtifactCmd" );
+    private final String requestCommand;
 
     private final Logger logger;
 
     public MockAgent( Logger logger )
     {
         this.logger = logger;
+        this.requestCommand = System.getProperty( "xmvn.resolver.requestArtifactCmd" );
     }
 
     public boolean tryInstallArtifact( Artifact artifact )
     {
-        if ( REQUEST_CMD == null )
+        if ( requestCommand == null )
             return false;
 
         try
         {
-            String cmd = String.format( "%s maven '%s'", REQUEST_CMD, artifact.toString() );
+            String cmd = String.format( "%s maven '%s'", requestCommand, artifact.toString() );
             logger.debug( "Trying to install artifact with external command: {}", cmd );
 
             ProcessBuilder pb = new ProcessBuilder( "sh", "-c", cmd );


### PR DESCRIPTION
The resolver test sets the request command system property, but at that
time the class might have been already loaded and thus it has no effect.
Which is what happens when executing the full test suite. This fixes the
failing test.