### PR TITLE
Support setting "-Xdoclint:none" in m-javadoc-p >= 3.0.0

### DIFF
--- a/xmvn-connector-aether/src/main/java/org/fedoraproject/xmvn/connector/aether/XMvnMojoExecutionListener.java
+++ b/xmvn-connector-aether/src/main/java/org/fedoraproject/xmvn/connector/aether/XMvnMojoExecutionListener.java
@@ -267,7 +267,10 @@ public class XMvnMojoExecutionListener
         // Disable doclint
         if ( JAVADOC_AGGREGATE.equals( execution ) )
         {
+            // maven-javadoc-plugin < 3.0.0
             trySetBeanProperty( mojo, "additionalparam", "-Xdoclint:none" );
+            // maven-javadoc-plugin >= 3.0.0
+            trySetBeanProperty( mojo, "additionalOptions", new String[] { "-Xdoclint:none" } );
         }
         else if ( XMVN_BUILDDEP.equals( execution ) )
         {


### PR DESCRIPTION
maven-javadoc-plugin 3.0.0 replaced `additionalparam` string property
with `additionalOptions` list property.
See: https://issues.apache.org/jira/browse/MJAVADOC-368