### PR TITLE
[it] Run tools ITs with target/classes in classpath, whenever possible

### DIFF
--- a/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/AbstractIntegrationTest.java
+++ b/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/AbstractIntegrationTest.java
@@ -59,6 +59,11 @@ public abstract class AbstractIntegrationTest
         return baseDir;
     }
 
+    public Path getRootDir()
+    {
+        return getBaseDir().getParent().getParent().getParent();
+    }
+
     public void expandBaseDir( String source, String target )
         throws Exception
     {

--- a/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/maven/AbstractMavenIntegrationTest.java
+++ b/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/maven/AbstractMavenIntegrationTest.java
@@ -101,7 +101,7 @@ public abstract class AbstractMavenIntegrationTest
     {
         Properties originalProperties = System.getProperties();
         System.setProperties( null );
-        System.setProperty( "xmvn.it.rootDir", getBaseDir().getParent().getParent().getParent().toString() );
+        System.setProperty( "xmvn.it.rootDir", getRootDir().toString() );
         System.setProperty( "maven.home", getMavenHome().toString() );
         System.setProperty( "user.dir", getBaseDir().toString() );
         System.setProperty( "maven.multiModuleProjectDirectory", getBaseDir().toString() );

--- a/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/tool/BisectIntegrationTest.java
+++ b/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/tool/BisectIntegrationTest.java
@@ -31,7 +31,8 @@ public class BisectIntegrationTest
     private int runBisect()
         throws Exception
     {
-        return invokeTool( "xmvn-bisect", "-Dxmvn.config.sandbox=true", "clean", "compile" );
+        return invokeTool( "xmvn-bisect", "-Dxmvn.home=" + getMavenHome(), "-Dxmvn.config.sandbox=true", "clean",
+                           "compile" );
     }
 
     @Test


### PR DESCRIPTION
For XMvn JARs, replace path to JAR with corresponding path to target/classes so that debugging works out of the box.