### PR TITLE
Allow install repos to specify repo-specific suffix 

### DIFF
--- a/xmvn-tools/xmvn-install/src/main/java/org/fedoraproject/xmvn/repository/impl/JppRepository.java
+++ b/xmvn-tools/xmvn-install/src/main/java/org/fedoraproject/xmvn/repository/impl/JppRepository.java
@@ -30,14 +30,14 @@ import org.w3c.dom.Element;
 class JppRepository
     extends SimpleRepository
 {
-    public JppRepository( String namespace, Path root, Element filter )
+    public JppRepository( String namespace, Path root, Element filter, String suffix )
     {
-        super( namespace, root, filter );
+        super( namespace, root, filter, suffix );
     }
 
     @Override
     protected Path getArtifactPath( String pattern, String groupId, String artifactId, String extension,
-                                    String classifier, String version )
+                                    String classifier, String version, String suffix )
     {
         StringBuilder path = new StringBuilder();
 
@@ -48,6 +48,9 @@ class JppRepository
 
         if ( !classifier.isEmpty() )
             path.append( '-' ).append( classifier );
+
+        if ( !suffix.isEmpty() )
+            path.append( '-' ).append( suffix );
 
         if ( !extension.isEmpty() )
             path.append( '.' ).append( extension );

--- a/xmvn-tools/xmvn-install/src/main/java/org/fedoraproject/xmvn/repository/impl/JppRepositoryFactory.java
+++ b/xmvn-tools/xmvn-install/src/main/java/org/fedoraproject/xmvn/repository/impl/JppRepositoryFactory.java
@@ -30,8 +30,8 @@ class JppRepositoryFactory
     extends SimpleRepositoryFactory
 {
     @Override
-    protected Repository newInstance( String namespace, Path root, Element filter )
+    protected Repository newInstance( String namespace, Path root, Element filter, String suffix )
     {
-        return new JppRepository( namespace, root, filter );
+        return new JppRepository( namespace, root, filter, suffix );
     }
 }

--- a/xmvn-tools/xmvn-install/src/main/java/org/fedoraproject/xmvn/repository/impl/MavenRepository.java
+++ b/xmvn-tools/xmvn-install/src/main/java/org/fedoraproject/xmvn/repository/impl/MavenRepository.java
@@ -30,14 +30,14 @@ import org.w3c.dom.Element;
 class MavenRepository
     extends SimpleRepository
 {
-    public MavenRepository( String namespace, Path root, Element filter )
+    public MavenRepository( String namespace, Path root, Element filter, String suffix )
     {
-        super( namespace, root, filter );
+        super( namespace, root, filter, suffix );
     }
 
     @Override
     protected Path getArtifactPath( String pattern, String groupId, String artifactId, String extension,
-                                    String classifier, String version )
+                                    String classifier, String version, String suffix )
     {
         if ( version == null )
             return null;

--- a/xmvn-tools/xmvn-install/src/main/java/org/fedoraproject/xmvn/repository/impl/MavenRepositoryFactory.java
+++ b/xmvn-tools/xmvn-install/src/main/java/org/fedoraproject/xmvn/repository/impl/MavenRepositoryFactory.java
@@ -30,8 +30,8 @@ class MavenRepositoryFactory
     extends SimpleRepositoryFactory
 {
     @Override
-    protected Repository newInstance( String namespace, Path root, Element filter )
+    protected Repository newInstance( String namespace, Path root, Element filter, String suffix )
     {
-        return new MavenRepository( namespace, root, filter );
+        return new MavenRepository( namespace, root, filter, suffix );
     }
 }

--- a/xmvn-tools/xmvn-install/src/main/java/org/fedoraproject/xmvn/repository/impl/SimpleRepository.java
+++ b/xmvn-tools/xmvn-install/src/main/java/org/fedoraproject/xmvn/repository/impl/SimpleRepository.java
@@ -35,15 +35,18 @@ abstract class SimpleRepository
 
     private final Condition condition;
 
-    public SimpleRepository( String namespace, Path root, Element filter )
+    private final String suffix;
+
+    public SimpleRepository( String namespace, Path root, Element filter, String suffix )
     {
         super( namespace );
         this.root = root;
         this.condition = new Condition( filter );
+        this.suffix = suffix;
     }
 
     protected abstract Path getArtifactPath( String pattern, String groupId, String artifactId, String extension,
-                                             String classifier, String version );
+                                             String classifier, String version, String suffix );
 
     @Override
     public Path getPrimaryArtifactPath( Artifact artifact, ArtifactContext context, String pattern )
@@ -59,7 +62,7 @@ abstract class SimpleRepository
         if ( version.equals( Artifact.DEFAULT_VERSION ) )
             version = null;
 
-        Path path = getArtifactPath( pattern, groupId, artifactId, extension, classifier, version );
+        Path path = getArtifactPath( pattern, groupId, artifactId, extension, classifier, version, suffix );
         if ( path == null )
             return null;
 

--- a/xmvn-tools/xmvn-install/src/main/java/org/fedoraproject/xmvn/repository/impl/SimpleRepositoryFactory.java
+++ b/xmvn-tools/xmvn-install/src/main/java/org/fedoraproject/xmvn/repository/impl/SimpleRepositoryFactory.java
@@ -29,7 +29,7 @@ import org.fedoraproject.xmvn.repository.Repository;
 abstract class SimpleRepositoryFactory
     extends AbstractRepositoryFactory
 {
-    protected abstract Repository newInstance( String namespace, Path root, Element filter );
+    protected abstract Repository newInstance( String namespace, Path root, Element filter, String suffix );
 
     @Override
     public Repository getInstance( Element filter, Properties properties, Element configuration, String namespace )
@@ -40,6 +40,8 @@ abstract class SimpleRepositoryFactory
         if ( namespace == null || namespace.isEmpty() )
             namespace = properties.getProperty( "namespace", "" );
 
-        return newInstance( namespace, root, filter );
+        String suffix = properties.getProperty( "suffix", "" );
+
+        return newInstance( namespace, root, filter, suffix );
     }
 }

--- a/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/repository/impl/JppRepositoryTest.java
+++ b/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/repository/impl/JppRepositoryTest.java
@@ -38,7 +38,7 @@ public class JppRepositoryTest
 {
     @Test
     public void testJppRepository()
-        throws Exception
+            throws Exception
     {
         Configuration configuration = new Configuration();
         Repository repository = new Repository();
@@ -58,11 +58,41 @@ public class JppRepositoryTest
         Artifact artifact1 = new DefaultArtifact( "foo.bar", "the-artifact", "baz", "1.2.3" );
         ArtifactContext context1 = new ArtifactContext( artifact1 );
         assertEquals( Paths.get( "my-target/path/aid-1.2.3.baz" ),
-                      repo.getPrimaryArtifactPath( artifact1, context1, "my-target/path/aid" ) );
+                repo.getPrimaryArtifactPath( artifact1, context1, "my-target/path/aid" ) );
 
         Artifact artifact2 = artifact1.setVersion( null );
         ArtifactContext context2 = new ArtifactContext( artifact2 );
         assertEquals( Paths.get( "my-target/path/aid.baz" ),
-                      repo.getPrimaryArtifactPath( artifact2, context2, "my-target/path/aid" ) );
+                repo.getPrimaryArtifactPath( artifact2, context2, "my-target/path/aid" ) );
+    }
+    @Test
+    public void testSuffix()
+            throws Exception
+    {
+        Configuration configuration = new Configuration();
+        Repository repository = new Repository();
+        repository.setId( "my-repo-with-suffix" );
+        repository.setType( "jpp" );
+        repository.addProperty( "suffix", "mymodule-stream" );
+        configuration.addRepository( repository );
+
+        Configurator configurator = EasyMock.createMock( Configurator.class );
+        EasyMock.expect( configurator.getConfiguration() ).andReturn( configuration ).atLeastOnce();
+        EasyMock.replay( configurator );
+
+        RepositoryConfigurator repoConfigurator = new DefaultRepositoryConfigurator( configurator );
+        org.fedoraproject.xmvn.repository.Repository repo = repoConfigurator.configureRepository( "my-repo-with-suffix" );
+        EasyMock.verify( configurator );
+        assertNotNull( repo );
+
+        Artifact artifact1 = new DefaultArtifact( "foo.bar", "the-artifact", "baz", "1.2.3" );
+        ArtifactContext context1 = new ArtifactContext( artifact1 );
+        assertEquals( Paths.get( "my-target/path/aid-1.2.3-mymodule-stream.baz" ),
+                repo.getPrimaryArtifactPath( artifact1, context1, "my-target/path/aid" ) );
+
+        Artifact artifact2 = artifact1.setVersion( null );
+        ArtifactContext context2 = new ArtifactContext( artifact2 );
+        assertEquals( Paths.get( "my-target/path/aid-mymodule-stream.baz" ),
+                repo.getPrimaryArtifactPath( artifact2, context2, "my-target/path/aid" ) );
     }
 }


### PR DESCRIPTION
This makes JPP repos used for artifact installation to be able to specify optional suffix to be appended to each artifact path. Suffix can only be configured in configuration XML files.

For example, if slf4j was installed to a repo with "maven-3.5" suffix configured in XMvn configuration, artifact paths would be like:

- /usr/share/java/slf4j/api-maven-3.5.jar
- /usr/share/java/slf4j/slf4j-api-maven-3.5.jar
- /usr/share/maven-poms/slf4j/api-maven-3.5.pom
- /usr/share/maven-poms/slf4j/slf4j-api-maven-3.5.pom

Corresponding standard paths without suffix are:

- /usr/share/java/slf4j/api.jar
- /usr/share/java/slf4j/slf4j-api.jar
- /usr/share/maven-poms/slf4j/api.pom
- /usr/share/maven-poms/slf4j/slf4j-api.pom
