### PR TITLE
Allow specifying custom install repository

### DIFF
--- a/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/tool/InstallerIntegrationTest.java
+++ b/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/tool/InstallerIntegrationTest.java
@@ -52,7 +52,7 @@ public class InstallerIntegrationTest
     {
         expandBaseDirInPlace( "install-plan.xml" );
 
-        assertEquals( 0, invokeTool( "xmvn-install", "-n", "xyzzy", "-R", "install-plan.xml", "-d", "dest", "-X" ) );
+        assertEquals( 0, invokeTool( "xmvn-install", "-n", "xyzzy", "-R", "install-plan.xml", "-d", "dest", "-X", "-i", "custom-install" ) );
         assertFalse( getStdout().findAny().isPresent() );
         assertTrue( getStderr().anyMatch( line -> line.equals( "[INFO] Installation successful" ) ) );
 

--- a/xmvn-it/src/test/resources/testInstallJar/.xmvn/configuration.xml
+++ b/xmvn-it/src/test/resources/testInstallJar/.xmvn/configuration.xml
@@ -113,6 +113,10 @@
     </repository>
     <repository>
       <id>install</id>
+      <type>dummy-default-should-not-be-used</type>
+    </repository>
+    <repository>
+      <id>custom-install</id>
       <type>compound</type>
       <configuration>
         <repositories>

--- a/xmvn-tools/xmvn-install/src/main/java/org/fedoraproject/xmvn/tools/install/ArtifactInstaller.java
+++ b/xmvn-tools/xmvn-install/src/main/java/org/fedoraproject/xmvn/tools/install/ArtifactInstaller.java
@@ -23,8 +23,27 @@ import org.fedoraproject.xmvn.metadata.ArtifactMetadata;
  */
 public interface ArtifactInstaller
 {
-    void install( JavaPackage targetPackage, ArtifactMetadata am, PackagingRule rule, String basePackageName )
-        throws ArtifactInstallationException;
+    String DEFAULT_REPOSITORY_ID = "install";
+
+    default void install( JavaPackage targetPackage, ArtifactMetadata am, PackagingRule rule, String basePackageName, String repositoryId )
+            throws ArtifactInstallationException
+    {
+        if ( repositoryId.equals( DEFAULT_REPOSITORY_ID ) )
+        {
+            install( targetPackage, am, rule, basePackageName );
+        }
+        else
+        {
+            throw new UnsupportedOperationException( "This artifact installer does not support non-default repository." );
+        }
+    }
+
+    @Deprecated
+    default void install( JavaPackage targetPackage, ArtifactMetadata am, PackagingRule rule, String basePackageName )
+            throws ArtifactInstallationException
+    {
+        install( targetPackage, am, rule, basePackageName, DEFAULT_REPOSITORY_ID );
+    }
 
     void postInstallation()
         throws ArtifactInstallationException;

--- a/xmvn-tools/xmvn-install/src/main/java/org/fedoraproject/xmvn/tools/install/InstallationRequest.java
+++ b/xmvn-tools/xmvn-install/src/main/java/org/fedoraproject/xmvn/tools/install/InstallationRequest.java
@@ -32,6 +32,8 @@ public class InstallationRequest
 
     private Path descriptorRoot;
 
+    private String repositoryId;
+
     public boolean isCheckForUnmatchedRules()
     {
         return checkForUnmatchedRules;
@@ -81,4 +83,15 @@ public class InstallationRequest
     {
         this.descriptorRoot = descriptorRoot;
     }
+
+    public String getRepositoryId()
+    {
+        return repositoryId;
+    }
+
+    public void setRepositoryId( String repositoryId )
+    {
+        this.repositoryId = repositoryId;
+    }
+
 }

--- a/xmvn-tools/xmvn-install/src/main/java/org/fedoraproject/xmvn/tools/install/cli/InstallerCli.java
+++ b/xmvn-tools/xmvn-install/src/main/java/org/fedoraproject/xmvn/tools/install/cli/InstallerCli.java
@@ -51,6 +51,7 @@ public class InstallerCli
         request.setBasePackageName( cliRequest.getPackageName() );
         request.setInstallRoot( Paths.get( cliRequest.getDestDir() ) );
         request.setInstallationPlan( Paths.get( cliRequest.getPlanPath() ) );
+        request.setRepositoryId( cliRequest.getRepoId() );
 
         try
         {

--- a/xmvn-tools/xmvn-install/src/main/java/org/fedoraproject/xmvn/tools/install/cli/InstallerCliRequest.java
+++ b/xmvn-tools/xmvn-install/src/main/java/org/fedoraproject/xmvn/tools/install/cli/InstallerCliRequest.java
@@ -24,6 +24,7 @@ import com.beust.jcommander.DynamicParameter;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
+import org.fedoraproject.xmvn.tools.install.ArtifactInstaller;
 
 /**
  * @author Mikolaj Izdebski
@@ -50,6 +51,9 @@ class InstallerCliRequest
 
     @Parameter( names = { "-d", "--destination" }, description = "Destination directory" )
     private String destDir = ".xmvn/root";
+
+    @Parameter( names = { "-i", "--repository" }, description = "Installation repository ID" )
+    private String repoId = ArtifactInstaller.DEFAULT_REPOSITORY_ID;
 
     @DynamicParameter( names = "-D", description = "Define system property" )
     private Map<String, String> defines = new TreeMap<>();
@@ -140,6 +144,17 @@ class InstallerCliRequest
     {
         this.destDir = destDir;
     }
+
+    public String getRepoId()
+    {
+        return repoId;
+    }
+
+    public void setRepoId( String repoId )
+    {
+        this.repoId = repoId;
+    }
+
 
     public Map<String, String> getDefines()
     {

--- a/xmvn-tools/xmvn-install/src/main/java/org/fedoraproject/xmvn/tools/install/impl/DefaultArtifactInstaller.java
+++ b/xmvn-tools/xmvn-install/src/main/java/org/fedoraproject/xmvn/tools/install/impl/DefaultArtifactInstaller.java
@@ -71,7 +71,7 @@ class DefaultArtifactInstaller
     }
 
     @Override
-    public void install( JavaPackage targetPackage, ArtifactMetadata am, PackagingRule rule, String basePackageName )
+    public void install( JavaPackage targetPackage, ArtifactMetadata am, PackagingRule rule, String basePackageName, String repositoryId )
         throws ArtifactInstallationException
     {
         Artifact artifact = am.toArtifact();
@@ -90,9 +90,9 @@ class DefaultArtifactInstaller
 
         logger.info( "Installing artifact {}", artifact );
 
-        Repository repo = repositoryConfigurator.configureRepository( "install" );
+        Repository repo = repositoryConfigurator.configureRepository( repositoryId );
         if ( repo == null )
-            throw new ArtifactInstallationException( "Unable to configure installation repository" );
+            throw new ArtifactInstallationException( "Unable to configure installation repository: " + repositoryId );
 
         Set<Path> basePaths = new LinkedHashSet<>();
         for ( String fileName : rule.getFiles() )

--- a/xmvn-tools/xmvn-install/src/main/java/org/fedoraproject/xmvn/tools/install/impl/DefaultInstaller.java
+++ b/xmvn-tools/xmvn-install/src/main/java/org/fedoraproject/xmvn/tools/install/impl/DefaultInstaller.java
@@ -210,7 +210,7 @@ public class DefaultInstaller
                                                                           artifactState.getMetadata().getProperties() ) );
     }
 
-    private void installArtifact( ArtifactState artifactState, String basePackageName )
+    private void installArtifact( ArtifactState artifactState, String basePackageName, String repositoryId )
         throws ArtifactInstallationException
     {
         JavaPackage targetPackage = artifactState.getTargetPackage();
@@ -220,7 +220,7 @@ public class DefaultInstaller
             ArtifactInstaller installer = artifactState.getInstaller();
             ArtifactMetadata metadata = artifactState.getMetadata();
             PackagingRule packagingRule = artifactState.getPackagingRule();
-            installer.install( targetPackage, metadata, packagingRule, basePackageName );
+            installer.install( targetPackage, metadata, packagingRule, basePackageName, repositoryId );
         }
     }
 
@@ -332,7 +332,7 @@ public class DefaultInstaller
                                   artifactState.getInstaller().getClass().getName() );
             }
 
-            installArtifact( artifactState, request.getBasePackageName() );
+            installArtifact( artifactState, request.getBasePackageName(), request.getRepositoryId() );
         }
 
         logger.debug( "Running post-installation hooks" );

--- a/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/tools/install/impl/ArtifactInstallerFactoryTest.java
+++ b/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/tools/install/impl/ArtifactInstallerFactoryTest.java
@@ -57,6 +57,7 @@ public class ArtifactInstallerFactoryTest
 
     @Test
     public void testValidPlugin()
+        throws Exception
     {
         Path pluginDir = Paths.get( "src/test/resources/plugins" ).toAbsolutePath();
         ArtifactInstallerFactory aif = new ArtifactInstallerFactory( null, pluginDir );
@@ -64,6 +65,43 @@ public class ArtifactInstallerFactoryTest
         props.setProperty( "type", "myplugin1" );
         ArtifactInstaller inst = aif.getInstallerFor( null, props );
         assertEquals( "foo.bar.MyPlugin", inst.getClass().getCanonicalName() );
+
+        try
+        {
+            // Deprecated call without repoId specified
+            inst.install( null, null, null, null );
+            fail( "Expected UnsupportedOperationException" );
+        }
+        catch ( UnsupportedOperationException e )
+        {
+            // "Not implemented exception" is thrown by the plugin
+            assertEquals( "Not implemented", e.getMessage() );
+            assertEquals( "foo.bar.MyPlugin.install(MyPlugin.java:16)", e.getStackTrace()[0].toString() );
+        }
+
+        try
+        {
+            // Modern call with default repoId
+            inst.install( null, null, null, null, "install" );
+            fail( "Expected UnsupportedOperationException" );
+        }
+        catch ( UnsupportedOperationException e )
+        {
+            // "Not implemented exception" is thrown by the plugin
+            assertEquals( "Not implemented", e.getMessage() );
+            assertEquals( "foo.bar.MyPlugin.install(MyPlugin.java:16)", e.getStackTrace()[0].toString() );
+        }
+
+        try
+        {
+            // Modern call with non-default repoId
+            inst.install( null, null, null, null, "my-repo" );
+            fail( "Expected UnsupportedOperationException" );
+        }
+        catch ( UnsupportedOperationException e )
+        {
+            assertEquals( "This artifact installer does not support non-default repository.", e.getMessage() );
+        }
     }
 
     @Test
@@ -85,5 +123,4 @@ public class ArtifactInstallerFactoryTest
             assertTrue( ReflectiveOperationException.class.isAssignableFrom( e.getCause().getClass() ) );
         }
     }
-
 }

--- a/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/tools/install/impl/ArtifactInstallerTest.java
+++ b/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/tools/install/impl/ArtifactInstallerTest.java
@@ -70,7 +70,7 @@ public class ArtifactInstallerTest
             @Override
             public Repository configureRepository( String repoId )
             {
-                assertEquals( "install", repoId );
+                assertEquals( "my-install-repo", repoId );
                 return repositoryMock;
             }
 
@@ -94,7 +94,7 @@ public class ArtifactInstallerTest
         expect( repositoryMock.getNamespace() ).andReturn( "ns" );
         replay( repositoryMock );
 
-        installer.install( pkg, am, rule, "foo" );
+        installer.install( pkg, am, rule, "foo", "my-install-repo" );
 
         verify( repositoryMock );
     }

--- a/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/tools/install/impl/InstallerTest.java
+++ b/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/tools/install/impl/InstallerTest.java
@@ -19,6 +19,7 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 import static org.fedoraproject.xmvn.tools.install.impl.InstallationPlanLoader.prepareInstallationPlanFile;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.nio.file.Path;
@@ -41,7 +42,6 @@ import org.fedoraproject.xmvn.metadata.ArtifactMetadata;
 import org.fedoraproject.xmvn.resolver.ResolutionRequest;
 import org.fedoraproject.xmvn.resolver.ResolutionResult;
 import org.fedoraproject.xmvn.resolver.Resolver;
-import org.fedoraproject.xmvn.tools.install.ArtifactInstallationException;
 import org.fedoraproject.xmvn.tools.install.ArtifactInstaller;
 import org.fedoraproject.xmvn.tools.install.File;
 import org.fedoraproject.xmvn.tools.install.InstallationRequest;
@@ -76,9 +76,10 @@ public class InstallerTest
     {
         @Override
         public void install( JavaPackage targetPackage, ArtifactMetadata artifactMetadata, PackagingRule packagingRule,
-                             String basePackageName )
-            throws ArtifactInstallationException
+                             String basePackageName, String repositoryId )
         {
+            assertEquals( "test-pkg", basePackageName );
+            assertEquals( "test-repo", repositoryId );
             Path path = Paths.get( "usr/share/java/" + artifactMetadata.getArtifactId() + ".jar" );
             File file = new RegularFile( path, Paths.get( artifactMetadata.getPath() ) );
             targetPackage.addFile( file );
@@ -87,7 +88,6 @@ public class InstallerTest
 
         @Override
         public void postInstallation()
-            throws ArtifactInstallationException
         {
         }
     }
@@ -148,6 +148,7 @@ public class InstallerTest
 
         InstallationRequest request = new InstallationRequest();
         request.setBasePackageName( "test-pkg" );
+        request.setRepositoryId( "test-repo" );
         request.setInstallRoot( installRoot );
         request.setDescriptorRoot( descriptorRoot );
         request.setInstallationPlan( prepareInstallationPlanFile( planName ) );


### PR DESCRIPTION
This makes xmvn-install to be able to select different repository (configured in XML configuration) to be used for artifact installation, instead of default "install" repo.