### PR TITLE
Avoid creating temp files during manifest injection

### DIFF
--- a/xmvn-tools/xmvn-install/src/main/java/org/fedoraproject/xmvn/tools/install/JarUtils.java
+++ b/xmvn-tools/xmvn-install/src/main/java/org/fedoraproject/xmvn/tools/install/JarUtils.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.util.Enumeration;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
@@ -218,8 +217,8 @@ public final class JarUtils
                 {
                     Manifest mf = new Manifest( jar.getInputStream( manifestEntry ) );
                     updateManifest( artifact, mf );
-                    Path tempJar = Files.createTempFile( "xmvn", ".tmp" );
-                    try ( ZipArchiveOutputStream os = new ZipArchiveOutputStream( tempJar.toFile() ) )
+                    Files.delete( targetJar );
+                    try ( ZipArchiveOutputStream os = new ZipArchiveOutputStream( targetJar.toFile() ) )
                     {
                         // write manifest
                         ZipArchiveEntry newManifestEntry = new ZipArchiveEntry( MANIFEST_PATH );
@@ -234,7 +233,6 @@ public final class JarUtils
                         // Re-throw exceptions that occur when processing JAR file after reading header and manifest.
                         throw new RuntimeException( e );
                     }
-                    Files.move( tempJar, targetJar, StandardCopyOption.REPLACE_EXISTING );
                     LOGGER.trace( "Manifest injected successfully" );
                 }
                 else


### PR DESCRIPTION
JDK seems to create temp files with umask 077, which results in wrong permissions on some installed files. See [rhbz#1579236](https://bugzilla.redhat.com/show_bug.cgi?id=1579236) for the original bug report.

This PR reverts to in-place manifest injection. JAR file is first opened, then unlinked, but i-node and file contents remain on disk. Then new file (new i-node) is created with the old name and new data written into it. This avoids creating any temporary files.

CC @mbooth101