### PR TITLE
Fixes #56 - Honour source parameter in javadoc mojo

### DIFF
--- a/xmvn-mojo/src/main/java/org/fedoraproject/xmvn/mojo/JavadocMojo.java
+++ b/xmvn-mojo/src/main/java/org/fedoraproject/xmvn/mojo/JavadocMojo.java
@@ -84,6 +84,9 @@ public class JavadocMojo
     @Parameter( defaultValue = "${project.build.directory}", required = true )
     private File buildDirectory;
 
+    @Parameter( property = "source" )
+    private String source;
+
     private static String quoted( Object obj )
     {
         String arg = obj.toString();
@@ -226,6 +229,10 @@ public class JavadocMojo
             opts.add( quoted( docencoding ) );
             opts.add( "-doctitle" );
             opts.add( quoted( "Javadoc for package XXX" ) );
+            if ( source != null ) {
+                opts.add( "-source" );
+                opts.add( quoted( source ) );
+            }
 
             for ( Path file : files )
                 opts.add( quoted( file ) );


### PR DESCRIPTION
This parameter is used by maven-javadoc-plugin to handle assert
and enum keywords that are used as identifiers in old code.