### PR TITLE
Switch binary distribution format back to TAR

### DIFF
--- a/src/main/assembly/bin.xml
+++ b/src/main/assembly/bin.xml
@@ -17,7 +17,7 @@
 <assembly>
   <id>bin</id>
   <formats>
-    <format>zip</format>
+    <format>tar.gz</format>
   </formats>
   <dependencySets>
     <dependencySet>

--- a/xmvn-it/pom.xml
+++ b/xmvn-it/pom.xml
@@ -38,7 +38,7 @@
       <artifactId>xmvn</artifactId>
       <version>${project.version}</version>
       <classifier>bin</classifier>
-      <type>zip</type>
+      <type>tar.gz</type>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -114,7 +114,7 @@
                   <artifactId>xmvn</artifactId>
                   <version>${project.version}</version>
                   <classifier>bin</classifier>
-                  <type>zip</type>
+                  <type>tar.gz</type>
                 </artifactItem>
               </artifactItems>
             </configuration>


### PR DESCRIPTION
ZIP is not able to handle symbolic links.