### PR TITLE
Javadoc exclusion

### DIFF
--- a/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/maven/mojo/javadoc/JavadocExcludePackagesRegexTest.java
+++ b/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/maven/mojo/javadoc/JavadocExcludePackagesRegexTest.java
@@ -1,0 +1,50 @@
+/*-
+ * Copyright (c) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fedoraproject.xmvn.it.maven.mojo.javadoc;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Test;
+
+import org.fedoraproject.xmvn.it.maven.mojo.AbstractMojoIntegrationTest;
+
+/**
+ * Integration tests for javadoc MOJO.
+ * 
+ * @author Marian Koncek
+ */
+public class JavadocExcludePackagesRegexTest
+    extends AbstractMojoIntegrationTest
+{
+    @Test
+    public void testJavadocExcludePackagesRegex()
+        throws Exception
+    {
+        performTest( "org.fedoraproject.xmvn:xmvn-mojo:javadoc" );
+
+        assertTrue( Files.isDirectory( Paths.get( "target/xmvn-apidocs/b/y" ) ) );
+        assertTrue( Files.isDirectory( Paths.get( "target/xmvn-apidocs/b/z" ) ) );
+        assertTrue( Files.isDirectory( Paths.get( "target/xmvn-apidocs/c/z" ) ) );
+
+        assertTrue( Files.notExists( Paths.get( "target/xmvn-apidocs/a" ) ) );
+        assertTrue( Files.notExists( Paths.get( "target/xmvn-apidocs/b/x" ) ) );
+        assertTrue( Files.notExists( Paths.get( "target/xmvn-apidocs/c/x" ) ) );
+        assertTrue( Files.notExists( Paths.get( "target/xmvn-apidocs/c/y" ) ) );
+    }
+}

--- a/xmvn-it/src/test/resources/testJavadocExcludePackagesRegex/.xmvn/configuration.xml
+++ b/xmvn-it/src/test/resources/testJavadocExcludePackagesRegex/.xmvn/configuration.xml
@@ -1,0 +1,7 @@
+<configuration>
+  <resolverSettings>
+    <metadataRepositories>
+      <repository>metadata.xml</repository>
+    </metadataRepositories>
+  </resolverSettings>
+</configuration>

--- a/xmvn-it/src/test/resources/testJavadocExcludePackagesRegex/pom.xml
+++ b/xmvn-it/src/test/resources/testJavadocExcludePackagesRegex/pom.xml
@@ -1,0 +1,36 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>xmvn.its</groupId>
+  <artifactId>javadoc-test-exclude-package-names</artifactId>
+  <version>0.0.0-SNAPSHOT</version>
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.6.0</version>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <release>11</release>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.fedoraproject.xmvn</groupId>
+        <artifactId>xmvn-mojo</artifactId>
+          <configuration>
+              <!-- Exclude fully-qualified classes matching either one of:
+              - a.*
+              - *.x
+              - c/y.*
+              -->
+            <javadocExcludePackagesRegex>^(?:a.*$)|(?:.*x/[^/]*$)|(c/y/[^/]*$)</javadocExcludePackagesRegex>
+          </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/xmvn-it/src/test/resources/testJavadocExcludePackagesRegex/src/main/java/a/x/Main.java
+++ b/xmvn-it/src/test/resources/testJavadocExcludePackagesRegex/src/main/java/a/x/Main.java
@@ -1,0 +1,28 @@
+/*-
+ * Copyright (c) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package a.x;
+
+/**
+ * Interface description.
+ * @author Marian Koncek
+ */
+public interface Main
+{
+    /**
+     * Method description
+     */
+    void method();
+}

--- a/xmvn-it/src/test/resources/testJavadocExcludePackagesRegex/src/main/java/a/y/Main.java
+++ b/xmvn-it/src/test/resources/testJavadocExcludePackagesRegex/src/main/java/a/y/Main.java
@@ -1,0 +1,28 @@
+/*-
+ * Copyright (c) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package a.y;
+
+/**
+ * Interface description.
+ * @author Marian Koncek
+ */
+public interface Main
+{
+    /**
+     * Method description
+     */
+    void method();
+}

--- a/xmvn-it/src/test/resources/testJavadocExcludePackagesRegex/src/main/java/a/z/Main.java
+++ b/xmvn-it/src/test/resources/testJavadocExcludePackagesRegex/src/main/java/a/z/Main.java
@@ -1,0 +1,28 @@
+/*-
+ * Copyright (c) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package a.z;
+
+/**
+ * Interface description.
+ * @author Marian Koncek
+ */
+public interface Main
+{
+    /**
+     * Method description
+     */
+    void method();
+}

--- a/xmvn-it/src/test/resources/testJavadocExcludePackagesRegex/src/main/java/b/x/Main.java
+++ b/xmvn-it/src/test/resources/testJavadocExcludePackagesRegex/src/main/java/b/x/Main.java
@@ -1,0 +1,28 @@
+/*-
+ * Copyright (c) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package b.x;
+
+/**
+ * Interface description.
+ * @author Marian Koncek
+ */
+public interface Main
+{
+    /**
+     * Method description
+     */
+    void method();
+}

--- a/xmvn-it/src/test/resources/testJavadocExcludePackagesRegex/src/main/java/b/y/Main.java
+++ b/xmvn-it/src/test/resources/testJavadocExcludePackagesRegex/src/main/java/b/y/Main.java
@@ -1,0 +1,28 @@
+/*-
+ * Copyright (c) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package b.y;
+
+/**
+ * Interface description.
+ * @author Marian Koncek
+ */
+public interface Main
+{
+    /**
+     * Method description
+     */
+    void method();
+}

--- a/xmvn-it/src/test/resources/testJavadocExcludePackagesRegex/src/main/java/b/z/Main.java
+++ b/xmvn-it/src/test/resources/testJavadocExcludePackagesRegex/src/main/java/b/z/Main.java
@@ -1,0 +1,28 @@
+/*-
+ * Copyright (c) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package b.z;
+
+/**
+ * Interface description.
+ * @author Marian Koncek
+ */
+public interface Main
+{
+    /**
+     * Method description
+     */
+    void method();
+}

--- a/xmvn-it/src/test/resources/testJavadocExcludePackagesRegex/src/main/java/c/x/Main.java
+++ b/xmvn-it/src/test/resources/testJavadocExcludePackagesRegex/src/main/java/c/x/Main.java
@@ -1,0 +1,28 @@
+/*-
+ * Copyright (c) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package c.x;
+
+/**
+ * Interface description.
+ * @author Marian Koncek
+ */
+public interface Main
+{
+    /**
+     * Method description
+     */
+    void method();
+}

--- a/xmvn-it/src/test/resources/testJavadocExcludePackagesRegex/src/main/java/c/y/Main.java
+++ b/xmvn-it/src/test/resources/testJavadocExcludePackagesRegex/src/main/java/c/y/Main.java
@@ -1,0 +1,28 @@
+/*-
+ * Copyright (c) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package c.y;
+
+/**
+ * Interface description.
+ * @author Marian Koncek
+ */
+public interface Main
+{
+    /**
+     * Method description
+     */
+    void method();
+}

--- a/xmvn-it/src/test/resources/testJavadocExcludePackagesRegex/src/main/java/c/z/Main.java
+++ b/xmvn-it/src/test/resources/testJavadocExcludePackagesRegex/src/main/java/c/z/Main.java
@@ -1,0 +1,28 @@
+/*-
+ * Copyright (c) 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package c.z;
+
+/**
+ * Interface description.
+ * @author Marian Koncek
+ */
+public interface Main
+{
+    /**
+     * Method description
+     */
+    void method();
+}


### PR DESCRIPTION
Currently the integration test fails with:
```
[ERROR] javadoc: error - File not found: "xcludePackageNames/src/main/java/b/z/Main.java"
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 31.526 s <<< FAILURE! - in org.fedoraproject.xmvn.it.maven.mojo.javadoc.JavadocExcludePackageNamesTest
[ERROR] org.fedoraproject.xmvn.it.maven.mojo.javadoc.JavadocExcludePackageNamesTest.testJavadocExcludePackageNames  Time elapsed: 31.167 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <0> but was: <1>
        at org.fedoraproject.xmvn.it.maven.mojo.javadoc.JavadocExcludePackageNamesTest.testJavadocExcludePackageNames(JavadocExcludePackageNamesTest.java:39)
```