### PR TITLE
Allow specifying source level for javadoc mojo

### DIFF
--- a/xmvn-mojo/src/main/java/org/fedoraproject/xmvn/mojo/JavadocMojo.java
+++ b/xmvn-mojo/src/main/java/org/fedoraproject/xmvn/mojo/JavadocMojo.java
@@ -78,6 +78,9 @@ public class JavadocMojo
     @Parameter( defaultValue = "${project.build.sourceEncoding}" )
     private String encoding;
 
+    @Parameter( property = "source", defaultValue = "${maven.compiler.source}" )
+    private String source;
+
     @Parameter( defaultValue = "${project.reporting.outputEncoding}" )
     private String docencoding;
 
@@ -234,6 +237,8 @@ public class JavadocMojo
             opts.add( quoted( StringUtils.join( fullClassPath.iterator(), ":" ) ) );
             opts.add( "-encoding" );
             opts.add( quoted( encoding ) );
+            opts.add( "-source" );
+            opts.add( quoted( source ) );
             opts.add( "-sourcepath" );
             opts.add( quoted( StringUtils.join( sourcePaths.iterator(), ":" ) ) );
             opts.add( "-charset" );


### PR DESCRIPTION
Allow specifying -source to the javadoc in the same way as one can do it to maven-javadoc-plugin:aggregate