### PR TITLE
Remove the args file from the javadoc tree once it is not needed any more

### DIFF
--- a/xmvn-mojo/src/main/java/org/fedoraproject/xmvn/mojo/JavadocMojo.java
+++ b/xmvn-mojo/src/main/java/org/fedoraproject/xmvn/mojo/JavadocMojo.java
@@ -234,7 +234,7 @@ public class JavadocMojo
     private void addOpt( String name )
     {
         options.add( name );
-        logger.debug( "Javadc option: {}", name );
+        logger.debug( "Javadoc option: {}", name );
     }
 
     private boolean addOpt( String name, String value )

--- a/xmvn-mojo/src/main/java/org/fedoraproject/xmvn/mojo/JavadocMojo.java
+++ b/xmvn-mojo/src/main/java/org/fedoraproject/xmvn/mojo/JavadocMojo.java
@@ -435,6 +435,8 @@ public class JavadocMojo
                          StandardOpenOption.TRUNCATE_EXISTING );
 
             invokeJavadoc( outputDir );
+
+            Files.deleteIfExists( outputDir.resolve( "args" ) );
         }
         catch ( IOException | InterruptedException e )
         {


### PR DESCRIPTION
The generated args file has a random order of source files. This makes the reproducible builds difficult. But this file does not need to be kept after the javadoc is generated, so delete it as any other temporary file once we don't use it. In case it is used for debugging or so, we could pipe it into the log before deleting, eventually.