### PR TITLE
Make metadata UUIDs reproducible if SOURCE_DATE_EPOCH is set

### DIFF
--- a/xmvn-tools/xmvn-install/src/main/java/org/fedoraproject/xmvn/tools/install/JavaPackage.java
+++ b/xmvn-tools/xmvn-install/src/main/java/org/fedoraproject/xmvn/tools/install/JavaPackage.java
@@ -58,7 +58,12 @@ public class JavaPackage
         super( id );
         this.basePackageName = basePackageName;
         this.metadataDir = metadataDir;
-        metadata.setUuid( UUID.randomUUID().toString() );
+        UUID guid = UUID.randomUUID();
+        if ( System.getenv( "SOURCE_DATE_EPOCH" ) != null )
+        {
+            guid = UUID.nameUUIDFromBytes( ( System.getenv( "SOURCE_DATE_EPOCH" ) + id + basePackageName + metadataDir.toString() ).getBytes() );
+        }
+        metadata.setUuid( guid.toString() );
     }
 
     /**
@@ -71,11 +76,16 @@ public class JavaPackage
     private PackageMetadata getSplitMetadata( String namespace )
     {
         PackageMetadata splitMetadata = new PackageMetadata();
-        splitMetadata.setUuid( UUID.randomUUID().toString() );
         splitMetadata.setProperties( metadata.getProperties() );
         List<ArtifactMetadata> allArtifacts = metadata.getArtifacts();
         List<ArtifactMetadata> splitArtifacts =
             allArtifacts.stream().filter( a -> namespace.equals( a.getNamespace() ) ).collect( Collectors.toList() );
+        UUID guid = UUID.randomUUID();
+        if ( System.getenv( "SOURCE_DATE_EPOCH" ) != null )
+        {
+            guid = UUID.nameUUIDFromBytes( ( System.getenv( "SOURCE_DATE_EPOCH" ) + splitArtifacts.toString() ).getBytes() );
+        }
+        splitMetadata.setUuid( guid.toString() );
         splitMetadata.setArtifacts( splitArtifacts );
         splitMetadata.setSkippedArtifacts( metadata.getSkippedArtifacts() );
         return splitMetadata;

--- a/xmvn-tools/xmvn-install/src/main/java/org/fedoraproject/xmvn/tools/install/impl/DefaultArtifactInstaller.java
+++ b/xmvn-tools/xmvn-install/src/main/java/org/fedoraproject/xmvn/tools/install/impl/DefaultArtifactInstaller.java
@@ -185,7 +185,12 @@ class DefaultArtifactInstaller
         am.setNamespace( repo.getNamespace() );
 
         // UUID
-        am.setUuid( UUID.randomUUID().toString() );
+        UUID guid = UUID.randomUUID();
+        if ( System.getenv( "SOURCE_DATE_EPOCH" ) != null )
+        {
+            guid = UUID.nameUUIDFromBytes( ( System.getenv( "SOURCE_DATE_EPOCH" ) + repo.getNamespace() + artifact.toString() ).getBytes() );
+        }
+        am.setUuid( guid.toString() );
 
         // Compat version
         for ( String version : rule.getVersions() )


### PR DESCRIPTION
This might be a bit controversial, but if the SOURCE_DATE_EPOCH is not set, everything is like before. Now, with this patch, the uuids are still unique in the package and also around the whole system, but they are the same if the zero-change rebuild is done. We run this since early August and everything works just fine. All xmvn tests and -Prun-its pass.

I rerun the whole build with this particular version of patch, just to be sure and the stuff is reproducible but still uuids are unique if SOURCE_DATE_EPOCH is set.