### PR TITLE
Drop --add-opens from Surefire configuration

### DIFF
--- a/xmvn-parent/pom.xml
+++ b/xmvn-parent/pom.xml
@@ -331,9 +331,6 @@
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${surefireVersion}</version>
-          <configuration>
-            <argLine>@{argLine} --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
-          </configuration>
         </plugin>
         <plugin>
           <groupId>com.diffplug.spotless</groupId>


### PR DESCRIPTION
The --add-opens is no longer needed with EasyMock 5.