### PR TITLE
Migrate tests to AssertJ fluent assertions

### DIFF
--- a/xmvn-api/src/test/java/org/fedoraproject/xmvn/artifact/ArtifactTest.java
+++ b/xmvn-api/src/test/java/org/fedoraproject/xmvn/artifact/ArtifactTest.java
@@ -15,12 +15,8 @@
  */
 package org.fedoraproject.xmvn.artifact;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
@@ -28,212 +24,216 @@ import org.junit.jupiter.api.Test;
 /**
  * @author Mikolaj Izdebski
  */
-public class ArtifactTest {
+class ArtifactTest {
     /** Test one-argument constructor. */
     @Test
-    public void testConstructor1() throws Exception {
+    void constructor1() throws Exception {
         Artifact artifact2 = Artifact.of("gid:aid");
-        assertEquals("gid", artifact2.getGroupId());
-        assertEquals("aid", artifact2.getArtifactId());
-        assertEquals("jar", artifact2.getExtension());
-        assertEquals("", artifact2.getClassifier());
-        assertEquals("SYSTEM", artifact2.getVersion());
-        assertNull(artifact2.getPath());
+        assertThat(artifact2.getGroupId()).isEqualTo("gid");
+        assertThat(artifact2.getArtifactId()).isEqualTo("aid");
+        assertThat(artifact2.getExtension()).isEqualTo("jar");
+        assertThat(artifact2.getClassifier()).isEqualTo("");
+        assertThat(artifact2.getVersion()).isEqualTo("SYSTEM");
+        assertThat(artifact2.getPath()).isNull();
 
         Artifact artifact3 = Artifact.of("gid:aid:ver");
-        assertEquals("gid", artifact3.getGroupId());
-        assertEquals("aid", artifact3.getArtifactId());
-        assertEquals("jar", artifact3.getExtension());
-        assertEquals("", artifact3.getClassifier());
-        assertEquals("ver", artifact3.getVersion());
-        assertNull(artifact3.getPath());
+        assertThat(artifact3.getGroupId()).isEqualTo("gid");
+        assertThat(artifact3.getArtifactId()).isEqualTo("aid");
+        assertThat(artifact3.getExtension()).isEqualTo("jar");
+        assertThat(artifact3.getClassifier()).isEqualTo("");
+        assertThat(artifact3.getVersion()).isEqualTo("ver");
+        assertThat(artifact3.getPath()).isNull();
 
         Artifact artifact4 = Artifact.of("gid:aid:ext:ver");
-        assertEquals("gid", artifact4.getGroupId());
-        assertEquals("aid", artifact4.getArtifactId());
-        assertEquals("ext", artifact4.getExtension());
-        assertEquals("", artifact4.getClassifier());
-        assertEquals("ver", artifact4.getVersion());
-        assertNull(artifact4.getPath());
+        assertThat(artifact4.getGroupId()).isEqualTo("gid");
+        assertThat(artifact4.getArtifactId()).isEqualTo("aid");
+        assertThat(artifact4.getExtension()).isEqualTo("ext");
+        assertThat(artifact4.getClassifier()).isEqualTo("");
+        assertThat(artifact4.getVersion()).isEqualTo("ver");
+        assertThat(artifact4.getPath()).isNull();
 
         Artifact artifact5 = Artifact.of("gid:aid:ext:cla:ver");
-        assertEquals("gid", artifact5.getGroupId());
-        assertEquals("aid", artifact5.getArtifactId());
-        assertEquals("ext", artifact5.getExtension());
-        assertEquals("cla", artifact5.getClassifier());
-        assertEquals("ver", artifact5.getVersion());
-        assertNull(artifact5.getPath());
+        assertThat(artifact5.getGroupId()).isEqualTo("gid");
+        assertThat(artifact5.getArtifactId()).isEqualTo("aid");
+        assertThat(artifact5.getExtension()).isEqualTo("ext");
+        assertThat(artifact5.getClassifier()).isEqualTo("cla");
+        assertThat(artifact5.getVersion()).isEqualTo("ver");
+        assertThat(artifact5.getPath()).isNull();
 
         // Empty extension
         Artifact artifact6 = Artifact.of("gid:aid::cla:ver");
-        assertEquals("gid", artifact6.getGroupId());
-        assertEquals("aid", artifact6.getArtifactId());
-        assertEquals("jar", artifact6.getExtension());
-        assertEquals("cla", artifact6.getClassifier());
-        assertEquals("ver", artifact6.getVersion());
-        assertNull(artifact6.getPath());
+        assertThat(artifact6.getGroupId()).isEqualTo("gid");
+        assertThat(artifact6.getArtifactId()).isEqualTo("aid");
+        assertThat(artifact6.getExtension()).isEqualTo("jar");
+        assertThat(artifact6.getClassifier()).isEqualTo("cla");
+        assertThat(artifact6.getVersion()).isEqualTo("ver");
+        assertThat(artifact6.getPath()).isNull();
 
         // Empty version
         Artifact artifact7 = Artifact.of("gid:aid:ext:cla:");
-        assertEquals("gid", artifact7.getGroupId());
-        assertEquals("aid", artifact7.getArtifactId());
-        assertEquals("ext", artifact7.getExtension());
-        assertEquals("cla", artifact7.getClassifier());
-        assertEquals("SYSTEM", artifact7.getVersion());
-        assertNull(artifact7.getPath());
+        assertThat(artifact7.getGroupId()).isEqualTo("gid");
+        assertThat(artifact7.getArtifactId()).isEqualTo("aid");
+        assertThat(artifact7.getExtension()).isEqualTo("ext");
+        assertThat(artifact7.getClassifier()).isEqualTo("cla");
+        assertThat(artifact7.getVersion()).isEqualTo("SYSTEM");
+        assertThat(artifact7.getPath()).isNull();
     }
 
     /** Test one-argument constructor with invalid coordinates. */
     @Test
-    public void testInvalidCoordinates() throws Exception {
-        assertThrows(IllegalArgumentException.class, () -> Artifact.of("foo"));
+    void invalidCoordinates() throws Exception {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> Artifact.of("foo"));
     }
 
     /** Test one-argument constructor with too many fields in coordinates. */
     @Test
-    public void testTooManyFields() throws Exception {
-        assertThrows(
-                IllegalArgumentException.class, () -> Artifact.of("gid:aid:ext:cla:ver:extra"));
+    void tooManyFields() throws Exception {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> Artifact.of("gid:aid:ext:cla:ver:extra"));
     }
 
     /** Test two-argument constructor with groupId as null pointer. */
     @Test
-    public void testGroupIdNull() throws Exception {
-        assertThrows(IllegalArgumentException.class, () -> Artifact.of(null, ""));
+    void groupIdNull() throws Exception {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> Artifact.of(null, ""));
     }
 
     /** Test two-argument constructor with artifactId as null pointer. */
     @Test
-    public void testArtifactIdNull() throws Exception {
-        assertThrows(IllegalArgumentException.class, () -> Artifact.of("gid", null));
+    void artifactIdNull() throws Exception {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> Artifact.of("gid", null));
     }
 
     /** Test two-argument constructor with groupId as null pointer. */
     @Test
-    public void testGroupIdEmpty() throws Exception {
-        assertThrows(IllegalArgumentException.class, () -> Artifact.of("", "aid"));
+    void groupIdEmpty() throws Exception {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> Artifact.of("", "aid"));
     }
 
     /** Test two-argument constructor with artifactId as null pointer. */
     @Test
-    public void testArtifactIdEmpty() throws Exception {
-        assertThrows(IllegalArgumentException.class, () -> Artifact.of("gid", ""));
+    void artifactIdEmpty() throws Exception {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> Artifact.of("gid", ""));
     }
 
     /** Test two-argument constructor. */
     @Test
-    public void testConstructor2() throws Exception {
+    void constructor2() throws Exception {
         Artifact artifact = Artifact.of("gid", "aid");
-        assertEquals("gid", artifact.getGroupId());
-        assertEquals("aid", artifact.getArtifactId());
-        assertEquals("jar", artifact.getExtension());
-        assertEquals("", artifact.getClassifier());
-        assertEquals("SYSTEM", artifact.getVersion());
-        assertNull(artifact.getPath());
+        assertThat(artifact.getGroupId()).isEqualTo("gid");
+        assertThat(artifact.getArtifactId()).isEqualTo("aid");
+        assertThat(artifact.getExtension()).isEqualTo("jar");
+        assertThat(artifact.getClassifier()).isEqualTo("");
+        assertThat(artifact.getVersion()).isEqualTo("SYSTEM");
+        assertThat(artifact.getPath()).isNull();
     }
 
     /** Test three-argument constructor. */
     @Test
-    public void testConstructor3() throws Exception {
+    void constructor3() throws Exception {
         Artifact artifact = Artifact.of("gid", "aid", "ver");
-        assertEquals("gid", artifact.getGroupId());
-        assertEquals("aid", artifact.getArtifactId());
-        assertEquals("jar", artifact.getExtension());
-        assertEquals("", artifact.getClassifier());
-        assertEquals("ver", artifact.getVersion());
-        assertNull(artifact.getPath());
+        assertThat(artifact.getGroupId()).isEqualTo("gid");
+        assertThat(artifact.getArtifactId()).isEqualTo("aid");
+        assertThat(artifact.getExtension()).isEqualTo("jar");
+        assertThat(artifact.getClassifier()).isEqualTo("");
+        assertThat(artifact.getVersion()).isEqualTo("ver");
+        assertThat(artifact.getPath()).isNull();
     }
 
     /** Test four-argument constructor. */
     @Test
-    public void testConstructor4() throws Exception {
+    void constructor4() throws Exception {
         Artifact artifact = Artifact.of("gid", "aid", "ext", "ver");
-        assertEquals("gid", artifact.getGroupId());
-        assertEquals("aid", artifact.getArtifactId());
-        assertEquals("ext", artifact.getExtension());
-        assertEquals("", artifact.getClassifier());
-        assertEquals("ver", artifact.getVersion());
-        assertNull(artifact.getPath());
+        assertThat(artifact.getGroupId()).isEqualTo("gid");
+        assertThat(artifact.getArtifactId()).isEqualTo("aid");
+        assertThat(artifact.getExtension()).isEqualTo("ext");
+        assertThat(artifact.getClassifier()).isEqualTo("");
+        assertThat(artifact.getVersion()).isEqualTo("ver");
+        assertThat(artifact.getPath()).isNull();
     }
 
     /** Test five-argument constructor. */
     @Test
-    public void testConstructor5() throws Exception {
+    void constructor5() throws Exception {
         Artifact artifact = Artifact.of("gid", "aid", "ext", "cla", "ver");
-        assertEquals("gid", artifact.getGroupId());
-        assertEquals("aid", artifact.getArtifactId());
-        assertEquals("ext", artifact.getExtension());
-        assertEquals("cla", artifact.getClassifier());
-        assertEquals("ver", artifact.getVersion());
-        assertNull(artifact.getPath());
+        assertThat(artifact.getGroupId()).isEqualTo("gid");
+        assertThat(artifact.getArtifactId()).isEqualTo("aid");
+        assertThat(artifact.getExtension()).isEqualTo("ext");
+        assertThat(artifact.getClassifier()).isEqualTo("cla");
+        assertThat(artifact.getVersion()).isEqualTo("ver");
+        assertThat(artifact.getPath()).isNull();
 
         Artifact artifact1 = Artifact.of("gid", "aid", "", "cla", "ver");
-        assertEquals("gid", artifact1.getGroupId());
-        assertEquals("aid", artifact1.getArtifactId());
-        assertEquals("jar", artifact1.getExtension());
-        assertEquals("cla", artifact1.getClassifier());
-        assertEquals("ver", artifact1.getVersion());
-        assertNull(artifact1.getPath());
+        assertThat(artifact1.getGroupId()).isEqualTo("gid");
+        assertThat(artifact1.getArtifactId()).isEqualTo("aid");
+        assertThat(artifact1.getExtension()).isEqualTo("jar");
+        assertThat(artifact1.getClassifier()).isEqualTo("cla");
+        assertThat(artifact1.getVersion()).isEqualTo("ver");
+        assertThat(artifact1.getPath()).isNull();
 
         Artifact artifact2 = Artifact.of("gid", "aid", "ext", "cla", "");
-        assertEquals("gid", artifact2.getGroupId());
-        assertEquals("aid", artifact2.getArtifactId());
-        assertEquals("ext", artifact2.getExtension());
-        assertEquals("cla", artifact2.getClassifier());
-        assertEquals("SYSTEM", artifact2.getVersion());
-        assertNull(artifact2.getPath());
+        assertThat(artifact2.getGroupId()).isEqualTo("gid");
+        assertThat(artifact2.getArtifactId()).isEqualTo("aid");
+        assertThat(artifact2.getExtension()).isEqualTo("ext");
+        assertThat(artifact2.getClassifier()).isEqualTo("cla");
+        assertThat(artifact2.getVersion()).isEqualTo("SYSTEM");
+        assertThat(artifact2.getPath()).isNull();
     }
 
     @Test
-    public void testSetVersion() throws Exception {
+    void setVersion() throws Exception {
         Artifact artifact = Artifact.of("gid:aid:ext:cla:ver");
         Artifact newArtifact = artifact.withVersion("1.2.3");
-        assertNotSame(artifact, newArtifact);
-        assertEquals("1.2.3", newArtifact.getVersion());
-        assertEquals("ver", artifact.getVersion());
+        assertThat(artifact).isNotSameAs(newArtifact);
+        assertThat(newArtifact.getVersion()).isEqualTo("1.2.3");
+        assertThat(artifact.getVersion()).isEqualTo("ver");
     }
 
     @Test
-    public void testSetPath() throws Exception {
+    void setPath() throws Exception {
         Artifact artifact = Artifact.of("gid:aid:ext:cla:ver");
         Artifact newArtifact = artifact.withPath(Path.of("/tmp/foo"));
-        assertNotSame(artifact, newArtifact);
-        assertEquals(Path.of("/tmp/foo"), newArtifact.getPath());
-        assertNull(artifact.getPath());
+        assertThat(artifact).isNotSameAs(newArtifact);
+        assertThat(newArtifact.getPath()).isEqualTo(Path.of("/tmp/foo"));
+        assertThat(artifact.getPath()).isNull();
     }
 
     /** Test if string conversion produces expected coordinates. */
     @Test
-    public void testToString() throws Exception {
+    void testToString() throws Exception {
         Artifact artifact2 = Artifact.of("gid", "aid");
-        assertEquals("gid:aid:jar:SYSTEM", artifact2.toString());
+        assertThat(artifact2.toString()).isEqualTo("gid:aid:jar:SYSTEM");
 
         Artifact artifact3 = Artifact.of("gid", "aid", "ver");
-        assertEquals("gid:aid:jar:ver", artifact3.toString());
+        assertThat(artifact3.toString()).isEqualTo("gid:aid:jar:ver");
 
         Artifact artifact4 = Artifact.of("gid", "aid", "ext", "ver");
-        assertEquals("gid:aid:ext:ver", artifact4.toString());
+        assertThat(artifact4.toString()).isEqualTo("gid:aid:ext:ver");
 
         Artifact artifact5 = Artifact.of("gid", "aid", "ext", "cla", "ver");
-        assertEquals("gid:aid:ext:cla:ver", artifact5.toString());
+        assertThat(artifact5.toString()).isEqualTo("gid:aid:ext:cla:ver");
     }
 
     /** Test if equality behaves sanely. */
     @Test
-    @SuppressWarnings("unlikely-arg-type")
-    public void testEquals() throws Exception {
+    void equals() throws Exception {
         Artifact artifact = Artifact.of("gid", "aid", "ext", "cla", "ver");
         Path path = Path.of("/some/path");
 
-        assertTrue(artifact.equals(artifact));
-        assertFalse(artifact.equals(null));
-        assertFalse(artifact.equals(42));
+        assertThat(artifact).isEqualTo(artifact);
+        assertThat(artifact).isNotEqualTo(null);
+        assertThat(artifact).isNotEqualTo(42);
 
         Artifact artifact0 = Artifact.of("gid:aid:ext:cla:ver");
 
-        assertTrue(artifact.equals(artifact0));
-        assertTrue(artifact.withPath(path).equals(artifact0.withPath(path)));
-        assertFalse(artifact.withPath(path).equals(artifact0));
+        assertThat(artifact0).isEqualTo(artifact);
+        assertThat(artifact0.withPath(path)).isEqualTo(artifact.withPath(path));
+        assertThat(artifact0).isNotEqualTo(artifact.withPath(path));
 
         Artifact artifact1 = Artifact.of("gidX", "aid", "ext", "cla", "ver");
         Artifact artifact2 = Artifact.of("gid", "aidX", "ext", "cla", "ver");
@@ -242,18 +242,18 @@ public class ArtifactTest {
         Artifact artifact5 = Artifact.of("gid", "aid", "ext", "cla", "verX");
         Artifact artifact6 = Artifact.of("gid", "aid", "ext", "cla", "ver").withPath(path);
 
-        assertFalse(artifact.equals(artifact1));
-        assertFalse(artifact.equals(artifact2));
-        assertFalse(artifact.equals(artifact3));
-        assertFalse(artifact.equals(artifact4));
-        assertFalse(artifact.equals(artifact5));
-        assertFalse(artifact.equals(artifact6));
+        assertThat(artifact1).isNotEqualTo(artifact);
+        assertThat(artifact2).isNotEqualTo(artifact);
+        assertThat(artifact3).isNotEqualTo(artifact);
+        assertThat(artifact4).isNotEqualTo(artifact);
+        assertThat(artifact5).isNotEqualTo(artifact);
+        assertThat(artifact6).isNotEqualTo(artifact);
     }
 
     @Test
-    public void testHashCode() throws Exception {
+    void testHashCode() throws Exception {
         Artifact artifact0 = Artifact.of("gid:aid:ext:cla:ver");
         Artifact artifact1 = Artifact.of("gid", "aid", "ext", "cla", "ver");
-        assertEquals(artifact0.hashCode(), artifact1.hashCode());
+        assertThat(artifact1.hashCode()).isEqualTo(artifact0.hashCode());
     }
 }

--- a/xmvn-api/src/test/java/org/fedoraproject/xmvn/config/ConfigurationTest.java
+++ b/xmvn-api/src/test/java/org/fedoraproject/xmvn/config/ConfigurationTest.java
@@ -21,7 +21,7 @@ import org.xmlunit.assertj3.XmlAssert;
 class ConfigurationTest {
 
     @Test
-    public void testEmpty() throws Exception {
+    void empty() throws Exception {
         String xml = "<configuration/>";
         Configuration conf = Configuration.fromXML(xml);
         String xml2 = conf.toXML();
@@ -29,7 +29,7 @@ class ConfigurationTest {
     }
 
     @Test
-    public void testAliases() throws Exception {
+    void aliases() throws Exception {
         String xml =
                 """
                 <configuration>
@@ -51,7 +51,7 @@ class ConfigurationTest {
     }
 
     @Test
-    public void testCompatVersions() throws Exception {
+    void compatVersions() throws Exception {
         String xml =
                 """
                 <configuration>

--- a/xmvn-api/src/test/java/org/fedoraproject/xmvn/config/DOMTest.java
+++ b/xmvn-api/src/test/java/org/fedoraproject/xmvn/config/DOMTest.java
@@ -32,7 +32,7 @@ class DOMTest {
                     DOM.of("foo", bean -> bean.dom, (bean, dom) -> bean.dom = dom));
 
     @Test
-    public void testSimpleDOM() throws Exception {
+    void simpleDOM() throws Exception {
         String xml =
                 """
 		        <test>
@@ -50,7 +50,7 @@ class DOMTest {
     }
 
     @Test
-    public void testMissingDOM() throws Exception {
+    void missingDOM() throws Exception {
         String xml =
                 """
 		        <test>

--- a/xmvn-api/src/test/java/org/fedoraproject/xmvn/metadata/MetadataTest.java
+++ b/xmvn-api/src/test/java/org/fedoraproject/xmvn/metadata/MetadataTest.java
@@ -15,8 +15,7 @@
  */
 package org.fedoraproject.xmvn.metadata;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
@@ -24,24 +23,22 @@ import org.junit.jupiter.api.Test;
 /**
  * @author Mikolaj Izdebski
  */
-public class MetadataTest {
+class MetadataTest {
     @Test
-    void testMetadataWithUuid() throws Exception {
+    void metadataWithUuid() throws Exception {
         PackageMetadata md =
                 PackageMetadata.readFromXML(Path.of("src/test/resources/metadata1.xml"));
-        assertEquals(2, md.getArtifacts().size());
+        assertThat(md.getArtifacts()).hasSize(2);
 
-        String xml = md.toXML();
-        assertFalse(xml.contains("uuid"));
+        assertThat(md.toXML()).doesNotContain("uuid");
     }
 
     @Test
-    void testMetadataWithoutUuid() throws Exception {
+    void metadataWithoutUuid() throws Exception {
         PackageMetadata md =
                 PackageMetadata.readFromXML(Path.of("src/test/resources/metadata2.xml"));
-        assertEquals(2, md.getArtifacts().size());
+        assertThat(md.getArtifacts()).hasSize(2);
 
-        String xml = md.toXML();
-        assertFalse(xml.contains("uuid"));
+        assertThat(md.toXML()).doesNotContain("uuid");
     }
 }

--- a/xmvn-api/src/test/java/org/fedoraproject/xmvn/resolver/ResolutionRequestTest.java
+++ b/xmvn-api/src/test/java/org/fedoraproject/xmvn/resolver/ResolutionRequestTest.java
@@ -15,8 +15,7 @@
  */
 package org.fedoraproject.xmvn.resolver;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.easymock.EasyMock;
 import org.fedoraproject.xmvn.artifact.Artifact;
@@ -26,13 +25,13 @@ import org.junit.jupiter.api.Test;
 /**
  * @author Roman Vais
  */
-public class ResolutionRequestTest {
+class ResolutionRequestTest {
     private Artifact artifact;
 
     private final ResolutionRequest rrq = new ResolutionRequest();
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         artifact = EasyMock.createMock(Artifact.class);
         rrq.setArtifact(null);
         rrq.setProviderNeeded(false);
@@ -41,55 +40,55 @@ public class ResolutionRequestTest {
 
     /** Test of get and set methods */
     @Test
-    public void getSetTest() throws Exception {
+    void getSetTest() throws Exception {
         // tests set and get artifact
         rrq.setArtifact(artifact);
-        assertTrue(artifact == rrq.getArtifact());
+        assertThat(artifact).isSameAs(rrq.getArtifact());
 
         // tests set and get 'ProviderNeeded'
         rrq.setProviderNeeded(true);
-        assertTrue(rrq.isProviderNeeded());
+        assertThat(rrq.isProviderNeeded()).isTrue();
         rrq.setProviderNeeded(false);
-        assertFalse(rrq.isProviderNeeded());
+        assertThat(rrq.isProviderNeeded()).isFalse();
 
         // tests set and get 'PersistentFileNeeded'
         rrq.setPersistentFileNeeded(true);
-        assertTrue(rrq.isPersistentFileNeeded());
+        assertThat(rrq.isPersistentFileNeeded()).isTrue();
         rrq.setPersistentFileNeeded(false);
-        assertFalse(rrq.isPersistentFileNeeded());
+        assertThat(rrq.isPersistentFileNeeded()).isFalse();
     }
 
     /** Test of constructor wit artifact argument */
     @Test
-    public void extraConstructorTest() throws Exception {
+    void extraConstructorTest() throws Exception {
         ResolutionRequest extraRq = new ResolutionRequest(artifact);
-        assertTrue(artifact == extraRq.getArtifact());
+        assertThat(artifact).isSameAs(extraRq.getArtifact());
     }
 
     /** Test of equality method */
     @Test
-    public void equalityTest() throws Exception {
-        assertTrue(rrq.equals(rrq));
-        assertFalse(rrq.equals(null));
-        assertFalse(rrq.equals(new Object()));
+    void equalityTest() throws Exception {
+        assertThat(rrq).isEqualTo(rrq);
+        assertThat(rrq).isNotEqualTo(null);
+        assertThat(new Object()).isNotEqualTo(rrq);
 
         ResolutionRequest extraRq = new ResolutionRequest();
-        assertTrue(rrq.equals(extraRq));
+        assertThat(extraRq).isEqualTo(rrq);
 
         extraRq.setArtifact(artifact);
-        assertFalse(rrq.equals(extraRq));
+        assertThat(extraRq).isNotEqualTo(rrq);
 
         rrq.setArtifact(artifact);
-        assertTrue(rrq.equals(extraRq));
+        assertThat(extraRq).isEqualTo(rrq);
 
         rrq.setProviderNeeded(true);
-        assertFalse(rrq.equals(extraRq));
+        assertThat(extraRq).isNotEqualTo(rrq);
 
         rrq.setProviderNeeded(false);
         rrq.setPersistentFileNeeded(true);
-        assertFalse(rrq.equals(extraRq));
+        assertThat(extraRq).isNotEqualTo(rrq);
 
         extraRq.setArtifact(EasyMock.createMock(Artifact.class));
-        assertFalse(rrq.equals(extraRq));
+        assertThat(extraRq).isNotEqualTo(rrq);
     }
 }

--- a/xmvn-connector/src/test/java/org/fedoraproject/xmvn/connector/maven/ModelTransformerTest.java
+++ b/xmvn-connector/src/test/java/org/fedoraproject/xmvn/connector/maven/ModelTransformerTest.java
@@ -15,8 +15,7 @@
  */
 package org.fedoraproject.xmvn.connector.maven;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.inject.Binder;
 import java.util.ArrayList;
@@ -51,7 +50,7 @@ public class ModelTransformerTest extends AbstractTest {
     }
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         configurator = lookup(Configurator.class);
         transformer = lookup(ModelTransformer.class);
 
@@ -98,14 +97,14 @@ public class ModelTransformerTest extends AbstractTest {
     }
 
     @Test
-    public void testMinimalModelTransformation() throws Exception {
+    void minimalModelTransformation() throws Exception {
         Model model = Model.newInstance();
-        assertTrue(transformer instanceof XMvnModelTransformer);
+        assertThat(transformer).isExactlyInstanceOf(XMvnModelTransformer.class);
         transformer.transformEffectiveModel(model);
     }
 
     @Test
-    public void testFullModelTransformation() throws Exception {
+    void fullModelTransformation() throws Exception {
         Model model =
                 Model.newBuilder()
                         .build(Build.newBuilder().extensions(el).plugins(pl).build())
@@ -115,7 +114,7 @@ public class ModelTransformerTest extends AbstractTest {
     }
 
     @Test
-    public void testRemovingTestDeps() throws Exception {
+    void removingTestDeps() throws Exception {
         configurator.getConfiguration().getBuildSettings().setSkipTests(true);
         dl.add(0, dl.remove(0).withScope("test"));
 
@@ -125,11 +124,11 @@ public class ModelTransformerTest extends AbstractTest {
                         .build();
         model = transformer.transformEffectiveModel(model);
 
-        assertEquals(0, model.getDependencies().size());
+        assertThat(model.getDependencies()).isEmpty();
     }
 
     @Test
-    public void testSkippedPlugins() throws Exception {
+    void skippedPlugins() throws Exception {
         Artifact sp1 = new Artifact();
         sp1.setArtifactId("maven-compiler-plugin");
         configurator.getConfiguration().getBuildSettings().getSkippedPlugins().add(sp1);
@@ -141,9 +140,9 @@ public class ModelTransformerTest extends AbstractTest {
         Model model = Model.newBuilder().build(Build.newBuilder().plugins(pl).build()).build();
         model = transformer.transformEffectiveModel(model);
 
-        assertEquals(1, model.getBuild().getPlugins().size());
+        assertThat(model.getBuild().getPlugins()).hasSize(1);
         Plugin plugin = model.getBuild().getPlugins().iterator().next();
-        assertEquals("foobar", plugin.getGroupId());
-        assertEquals("bar", plugin.getArtifactId());
+        assertThat(plugin.getGroupId()).isEqualTo("foobar");
+        assertThat(plugin.getArtifactId()).isEqualTo("bar");
     }
 }

--- a/xmvn-connector/src/test/java/org/fedoraproject/xmvn/connector/maven/PluginVersionResolverTest.java
+++ b/xmvn-connector/src/test/java/org/fedoraproject/xmvn/connector/maven/PluginVersionResolverTest.java
@@ -15,7 +15,7 @@
  */
 package org.fedoraproject.xmvn.connector.maven;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,21 +34,16 @@ import org.junit.jupiter.api.Test;
 /**
  * @author Roman Vais
  */
-public class PluginVersionResolverTest {
+class PluginVersionResolverTest {
     private PluginVersionResolver resolver;
-
     private PluginVersionRequest rq;
-
     private RepositorySystemSession session;
-
     private WorkspaceReader reader;
-
     private WorkspaceRepository repo;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         resolver = new XMvnPluginVersionResolver();
-
         rq = EasyMock.createStrictMock(PluginVersionRequest.class);
         session = EasyMock.createStrictMock(RepositorySystemSession.class);
         reader = EasyMock.createStrictMock(WorkspaceReader.class);
@@ -56,12 +51,12 @@ public class PluginVersionResolverTest {
     }
 
     @Test
-    public void testInjection() throws Exception {
-        assertTrue(resolver instanceof XMvnPluginVersionResolver);
+    void injection() throws Exception {
+        assertThat(resolver).isExactlyInstanceOf(XMvnPluginVersionResolver.class);
     }
 
     @Test
-    public void testResolution() throws Exception {
+    void resolution() throws Exception {
         // test of default version resolution (version list is empty)
         EasyMock.expect(rq.getRepositorySession()).andReturn(session);
         EasyMock.expect(rq.getGroupId()).andReturn("test.example");
@@ -78,8 +73,8 @@ public class PluginVersionResolverTest {
         PluginVersionResult result;
 
         result = resolver.resolve(rq);
-        assertTrue(result.getRepository().equals(repo));
-        assertTrue(result.getVersion().equals(Artifact.DEFAULT_VERSION));
+        assertThat(repo).isEqualTo(result.getRepository());
+        assertThat(result.getVersion()).isEqualTo(Artifact.DEFAULT_VERSION);
 
         EasyMock.verify(rq, session, reader);
 
@@ -101,8 +96,8 @@ public class PluginVersionResolverTest {
         EasyMock.replay(rq, session, reader);
 
         result = resolver.resolve(rq);
-        assertTrue(result.getRepository().equals(repo));
-        assertTrue("1.2.3".equals(result.getVersion()));
+        assertThat(repo).isEqualTo(result.getRepository());
+        assertThat(result.getVersion()).isEqualTo("1.2.3");
 
         EasyMock.verify(rq, session, reader);
     }

--- a/xmvn-connector/src/test/java/org/fedoraproject/xmvn/connector/maven/WorkspaceReaderTest.java
+++ b/xmvn-connector/src/test/java/org/fedoraproject/xmvn/connector/maven/WorkspaceReaderTest.java
@@ -15,12 +15,9 @@
  */
 package org.fedoraproject.xmvn.connector.maven;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.inject.Binder;
-import java.io.File;
 import java.nio.file.Path;
 import java.util.List;
 import org.easymock.EasyMock;
@@ -38,7 +35,6 @@ import org.junit.jupiter.api.Test;
  */
 public class WorkspaceReaderTest extends AbstractTest {
     private WorkspaceReader workspace;
-
     private Resolver resolver;
 
     @Override
@@ -47,21 +43,19 @@ public class WorkspaceReaderTest extends AbstractTest {
     }
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         resolver = EasyMock.createMock(Resolver.class);
         getContainer().addComponent(resolver, Resolver.class, "default");
-
         workspace = lookup(WorkspaceReader.class, "ide");
     }
 
     @Test
-    public void testDependencyInjection() throws Exception {
-        assertNotNull(workspace);
-        assertTrue(workspace instanceof XMvnWorkspaceReader);
+    void dependencyInjection() throws Exception {
+        assertThat(workspace).isExactlyInstanceOf(XMvnWorkspaceReader.class);
     }
 
     @Test
-    public void testFindArtifact() throws Exception {
+    void findArtifact() throws Exception {
         ResolutionRequest request = new ResolutionRequest(Artifact.of("foo:bar:1.2.3"));
         ResolutionResult result = EasyMock.createMock(ResolutionResult.class);
 
@@ -69,16 +63,16 @@ public class WorkspaceReaderTest extends AbstractTest {
         EasyMock.expect(result.getArtifactPath()).andReturn(Path.of("/foo/bar"));
         EasyMock.replay(resolver, result);
 
-        File file =
-                workspace.findArtifact(
+        Path path =
+                workspace.findArtifactPath(
                         new org.eclipse.aether.artifact.DefaultArtifact("foo:bar:1.2.3"));
         EasyMock.verify(resolver, result);
 
-        assertEquals(new File("/foo/bar"), file);
+        assertThat(path).isEqualTo(Path.of("/foo/bar"));
     }
 
     @Test
-    public void testArtifactNotFound() throws Exception {
+    void artifactNotFound() throws Exception {
         ResolutionRequest request = new ResolutionRequest(Artifact.of("foo:bar:1.2.3"));
         ResolutionResult result = EasyMock.createMock(ResolutionResult.class);
 
@@ -86,16 +80,16 @@ public class WorkspaceReaderTest extends AbstractTest {
         EasyMock.expect(result.getArtifactPath()).andReturn(null);
         EasyMock.replay(resolver, result);
 
-        File file =
-                workspace.findArtifact(
+        Path path =
+                workspace.findArtifactPath(
                         new org.eclipse.aether.artifact.DefaultArtifact("foo:bar:1.2.3"));
         EasyMock.verify(resolver, result);
 
-        assertEquals(null, file);
+        assertThat(path).isNull();
     }
 
     @Test
-    public void testFindVersionsSystem() throws Exception {
+    void findVersionsSystem() throws Exception {
         ResolutionRequest request = new ResolutionRequest(Artifact.of("foo:bar:1.2.3"));
         ResolutionResult result = EasyMock.createMock(ResolutionResult.class);
 
@@ -109,12 +103,12 @@ public class WorkspaceReaderTest extends AbstractTest {
                         new org.eclipse.aether.artifact.DefaultArtifact("foo:bar:1.2.3"));
         EasyMock.verify(resolver, result);
 
-        assertEquals(1, versions.size());
-        assertEquals("SYSTEM", versions.get(0));
+        assertThat(versions).hasSize(1);
+        assertThat(versions.get(0)).isEqualTo("SYSTEM");
     }
 
     @Test
-    public void testFindVersionsCompat() throws Exception {
+    void findVersionsCompat() throws Exception {
         ResolutionRequest request = new ResolutionRequest(Artifact.of("foo:bar:1.2.3"));
         ResolutionResult result = EasyMock.createMock(ResolutionResult.class);
 
@@ -128,12 +122,12 @@ public class WorkspaceReaderTest extends AbstractTest {
                         new org.eclipse.aether.artifact.DefaultArtifact("foo:bar:1.2.3"));
         EasyMock.verify(resolver, result);
 
-        assertEquals(1, versions.size());
-        assertEquals("4.5.6", versions.get(0));
+        assertThat(versions).hasSize(1);
+        assertThat(versions.get(0)).isEqualTo("4.5.6");
     }
 
     @Test
-    public void testFindVersionsNotFound() throws Exception {
+    void findVersionsNotFound() throws Exception {
         ResolutionRequest request = new ResolutionRequest(Artifact.of("foo:bar:1.2.3"));
         ResolutionResult result = EasyMock.createMock(ResolutionResult.class);
 
@@ -146,12 +140,12 @@ public class WorkspaceReaderTest extends AbstractTest {
                         new org.eclipse.aether.artifact.DefaultArtifact("foo:bar:1.2.3"));
         EasyMock.verify(resolver, result);
 
-        assertEquals(0, versions.size());
+        assertThat(versions).isEmpty();
     }
 
     @Test
-    public void testGetRepository() throws Exception {
+    void getRepository() throws Exception {
         WorkspaceRepository repository = workspace.getRepository();
-        assertNotNull(repository);
+        assertThat(repository).isNotNull();
     }
 }

--- a/xmvn-connector/src/test/java/org/fedoraproject/xmvn/connector/maven/XMvnMavenPluginValidatorTest.java
+++ b/xmvn-connector/src/test/java/org/fedoraproject/xmvn/connector/maven/XMvnMavenPluginValidatorTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 /**
  * @author Roman Vais
  */
-public class XMvnMavenPluginValidatorTest {
+class XMvnMavenPluginValidatorTest {
     private XMvnMavenPluginValidator validator;
 
     private Artifact art;
@@ -33,7 +33,7 @@ public class XMvnMavenPluginValidatorTest {
     private List<String> err;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         validator = new XMvnMavenPluginValidator();
         art = EasyMock.createMock(Artifact.class);
         desc = EasyMock.createMock(PluginDescriptor.class);
@@ -41,7 +41,7 @@ public class XMvnMavenPluginValidatorTest {
     }
 
     @Test
-    public void testMavenPluginValidator() throws Exception {
+    void mavenPluginValidator() throws Exception {
         EasyMock.expect(desc.getVersion()).andReturn(null);
         desc.setVersion(EasyMock.anyObject(String.class));
         EasyMock.expectLastCall();

--- a/xmvn-core/src/test/java/org/fedoraproject/xmvn/config/impl/ConfigurationMergerTest.java
+++ b/xmvn-core/src/test/java/org/fedoraproject/xmvn/config/impl/ConfigurationMergerTest.java
@@ -15,7 +15,7 @@
  */
 package org.fedoraproject.xmvn.config.impl;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.file.Path;
 import org.fedoraproject.xmvn.config.Configuration;
@@ -26,11 +26,11 @@ import org.junit.jupiter.api.Test;
 /**
  * @author Mikolaj Izdebski
  */
-public class ConfigurationMergerTest extends AbstractTest {
+class ConfigurationMergerTest extends AbstractTest {
     private ConfigurationMerger merger;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         merger = new ConfigurationMerger();
     }
 
@@ -39,7 +39,7 @@ public class ConfigurationMergerTest extends AbstractTest {
     }
 
     @Test
-    public void testMerge() throws Exception {
+    void merge() throws Exception {
         Configuration c1 =
                 Configuration.readFromXML(Path.of("src/test/resources/conf-dominant.xml"));
         Configuration c2 =
@@ -48,24 +48,24 @@ public class ConfigurationMergerTest extends AbstractTest {
                 Configuration.readFromXML(Path.of("src/test/resources/conf-superdominant.xml"));
 
         Configuration c3 = merger.merge(null, c2);
-        assertEquals(toString(c2), toString(c3));
+        assertThat(toString(c3)).isEqualTo(toString(c2));
 
         Configuration c5 = merger.merge(c1, c2);
 
         Configuration out = merger.merge(c4, c5);
 
-        assertEquals(3, out.getProperties().size());
-        assertEquals("v1", out.getProperties().get("p1"));
-        assertEquals("v2", out.getProperties().get("p2"));
-        assertEquals("v3", out.getProperties().get("p3"));
-        assertEquals(true, out.getBuildSettings().isDebug());
-        assertEquals(false, out.getBuildSettings().isSkipTests());
-        assertEquals(true, out.getResolverSettings().isDebug());
-        assertEquals(true, out.getInstallerSettings().isDebug());
-        assertEquals("/foo/bar", out.getInstallerSettings().getMetadataDir());
-        assertEquals(false, out.getResolverSettings().isIgnoreDuplicateMetadata());
+        assertThat(out.getProperties()).hasSize(3);
+        assertThat(out.getProperties().get("p1")).isEqualTo("v1");
+        assertThat(out.getProperties().get("p2")).isEqualTo("v2");
+        assertThat(out.getProperties().get("p3")).isEqualTo("v3");
+        assertThat(out.getBuildSettings().isDebug()).isTrue();
+        assertThat(out.getBuildSettings().isSkipTests()).isFalse();
+        assertThat(out.getResolverSettings().isDebug()).isTrue();
+        assertThat(out.getInstallerSettings().isDebug()).isTrue();
+        assertThat(out.getInstallerSettings().getMetadataDir()).isEqualTo("/foo/bar");
+        assertThat(out.getResolverSettings().isIgnoreDuplicateMetadata()).isFalse();
 
         Configuration c6 = merger.merge(c2, c2);
-        assertEquals(toString(c2), toString(c6));
+        assertThat(toString(c6)).isEqualTo(toString(c2));
     }
 }

--- a/xmvn-core/src/test/java/org/fedoraproject/xmvn/logging/impl/ConsoleLoggerTest.java
+++ b/xmvn-core/src/test/java/org/fedoraproject/xmvn/logging/impl/ConsoleLoggerTest.java
@@ -15,7 +15,7 @@
  */
 package org.fedoraproject.xmvn.logging.impl;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -41,36 +41,36 @@ class ConsoleLoggerTest {
     }
 
     @Test
-    void testIsDebugEnabled() {
+    void isDebugEnabled() {
         boolean debugExpected = System.getProperty("xmvn.debug") != null;
-        assertEquals(debugExpected, logger.isDebugEnabled());
+        assertThat(logger.isDebugEnabled()).isEqualTo(debugExpected);
     }
 
     @Test
-    void testDebugLogging() {
+    void debugLogging() {
         System.setProperty("xmvn.debug", "true");
         logger = new ConsoleLogger();
         logger.debug("Debug message {}", 123);
-        assertTrue(getLog().contains("DEBUG: Debug message 123"));
+        assertThat(getLog()).contains("DEBUG: Debug message 123");
         System.clearProperty("xmvn.debug");
     }
 
     @Test
-    void testInfoLogging() {
+    void infoLogging() {
         logger.info("Info message {}", 42);
-        assertTrue(getLog().contains("Info message 42"));
+        assertThat(getLog()).contains("Info message 42");
     }
 
     @Test
-    void testWarnLogging() {
+    void warnLogging() {
         logger.warn("Warning message {}");
-        assertTrue(getLog().contains("WARNING: Warning message"));
+        assertThat(getLog()).contains("WARNING: Warning message");
     }
 
     @Test
-    void testErrorLogging() {
+    void errorLogging() {
         logger.error("Error message {}", "Critical");
-        assertTrue(getLog().contains("ERROR: Error message Critical"));
+        assertThat(getLog()).contains("ERROR: Error message Critical");
     }
 
     @BeforeEach

--- a/xmvn-core/src/test/java/org/fedoraproject/xmvn/metadata/impl/MetadataReaderTest.java
+++ b/xmvn-core/src/test/java/org/fedoraproject/xmvn/metadata/impl/MetadataReaderTest.java
@@ -15,9 +15,7 @@
  */
 package org.fedoraproject.xmvn.metadata.impl;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -37,11 +35,11 @@ import org.junit.jupiter.api.Test;
 /**
  * @author Mikolaj Izdebski
  */
-public class MetadataReaderTest extends AbstractTest {
+class MetadataReaderTest extends AbstractTest {
     private DefaultMetadataResolver reader;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         reader = new DefaultMetadataResolver(locator);
     }
 
@@ -51,11 +49,10 @@ public class MetadataReaderTest extends AbstractTest {
      * @throws Exception
      */
     @Test
-    public void testReadingEmptyList() throws Exception {
+    void readingEmptyList() throws Exception {
         List<String> pathList = List.of();
         Map<Path, PackageMetadata> map = reader.readMetadata(pathList);
-        assertNotNull(map);
-        assertTrue(map.isEmpty());
+        assertThat(map).isEmpty();
     }
 
     /**
@@ -64,12 +61,11 @@ public class MetadataReaderTest extends AbstractTest {
      * @throws Exception
      */
     @Test
-    public void testReadingEmptyDirectory() throws Exception {
+    void readingEmptyDirectory() throws Exception {
         Path dir = Files.createTempDirectory("xmvn-test");
         List<String> pathList = List.of(dir.toString());
         Map<Path, PackageMetadata> map = reader.readMetadata(pathList);
-        assertNotNull(map);
-        assertTrue(map.isEmpty());
+        assertThat(map).isEmpty();
     }
 
     /**
@@ -78,7 +74,7 @@ public class MetadataReaderTest extends AbstractTest {
      * @throws Exception
      */
     @Test
-    public void testMetadata1() throws Exception {
+    void metadata1() throws Exception {
         testMetadata1("metadata1");
     }
 
@@ -88,122 +84,112 @@ public class MetadataReaderTest extends AbstractTest {
      * @throws Exception
      */
     @Test
-    public void testMetadata1WithNamespace() throws Exception {
+    void metadata1WithNamespace() throws Exception {
         testMetadata1("metadata1-ns");
     }
 
     private void testMetadata1(String fileName) throws Exception {
         List<String> pathList = List.of("src/test/resources/" + fileName + ".xml");
         Map<Path, PackageMetadata> map = reader.readMetadata(pathList);
-        assertNotNull(map);
-        assertEquals(1, map.size());
+        assertThat(map).hasSize(1);
 
         PackageMetadata pm = map.values().iterator().next();
 
-        assertNotNull(pm.getProperties());
-        assertEquals(1, pm.getProperties().size());
-        assertEquals("key", pm.getProperties().keySet().iterator().next());
-        assertEquals("value", pm.getProperties().values().iterator().next());
+        assertThat(pm.getProperties()).hasSize(1);
+        assertThat(pm.getProperties().keySet().iterator().next()).isEqualTo("key");
+        assertThat(pm.getProperties().values().iterator().next()).isEqualTo("value");
 
-        assertNotNull(pm.getArtifacts());
-        assertEquals(1, pm.getArtifacts().size());
+        assertThat(pm.getArtifacts()).hasSize(1);
         ArtifactMetadata am = pm.getArtifacts().iterator().next();
 
-        assertEquals("gid", am.getGroupId());
-        assertEquals("aid", am.getArtifactId());
-        assertEquals("ext", am.getExtension());
-        assertEquals("cla", am.getClassifier());
-        assertEquals("ver", am.getVersion());
-        assertEquals("/foo/bar", am.getPath());
-        assertEquals("myscl10", am.getNamespace());
+        assertThat(am.getGroupId()).isEqualTo("gid");
+        assertThat(am.getArtifactId()).isEqualTo("aid");
+        assertThat(am.getExtension()).isEqualTo("ext");
+        assertThat(am.getClassifier()).isEqualTo("cla");
+        assertThat(am.getVersion()).isEqualTo("ver");
+        assertThat(am.getPath()).isEqualTo("/foo/bar");
+        assertThat(am.getNamespace()).isEqualTo("myscl10");
 
-        assertNotNull(am.getProperties());
-        assertEquals(1, am.getProperties().size());
-        assertEquals("key1", am.getProperties().keySet().iterator().next());
-        assertEquals("value1", am.getProperties().values().iterator().next());
+        assertThat(am.getProperties()).hasSize(1);
+        assertThat(am.getProperties().keySet().iterator().next()).isEqualTo("key1");
+        assertThat(am.getProperties().values().iterator().next()).isEqualTo("value1");
 
-        assertNotNull(am.getCompatVersions());
-        assertEquals(1, am.getCompatVersions().size());
-        assertEquals("1.2-beta3", am.getCompatVersions().iterator().next());
+        assertThat(am.getCompatVersions()).hasSize(1);
+        assertThat(am.getCompatVersions().iterator().next()).isEqualTo("1.2-beta3");
 
-        assertNotNull(am.getAliases());
-        assertEquals(1, am.getAliases().size());
+        assertThat(am.getAliases()).hasSize(1);
         ArtifactAlias alias = am.getAliases().iterator().next();
 
-        assertEquals("a-gid", alias.getGroupId());
-        assertEquals("a-aid", alias.getArtifactId());
-        assertEquals("a-ext", alias.getExtension());
-        assertEquals("a-cla", alias.getClassifier());
+        assertThat(alias.getGroupId()).isEqualTo("a-gid");
+        assertThat(alias.getArtifactId()).isEqualTo("a-aid");
+        assertThat(alias.getExtension()).isEqualTo("a-ext");
+        assertThat(alias.getClassifier()).isEqualTo("a-cla");
 
-        assertNotNull(am.getDependencies());
-        assertEquals(1, am.getDependencies().size());
+        assertThat(am.getDependencies()).hasSize(1);
         Dependency dep = am.getDependencies().iterator().next();
 
-        assertEquals("d-gid", dep.getGroupId());
-        assertEquals("d-aid", dep.getArtifactId());
-        assertEquals("d-ext", dep.getExtension());
-        assertEquals("d-cla", dep.getClassifier());
-        assertEquals("1.2.3", dep.getRequestedVersion());
-        assertEquals("4.5.6", dep.getResolvedVersion());
-        assertEquals("xyzzy", dep.getNamespace());
+        assertThat(dep.getGroupId()).isEqualTo("d-gid");
+        assertThat(dep.getArtifactId()).isEqualTo("d-aid");
+        assertThat(dep.getExtension()).isEqualTo("d-ext");
+        assertThat(dep.getClassifier()).isEqualTo("d-cla");
+        assertThat(dep.getRequestedVersion()).isEqualTo("1.2.3");
+        assertThat(dep.getResolvedVersion()).isEqualTo("4.5.6");
+        assertThat(dep.getNamespace()).isEqualTo("xyzzy");
 
-        assertNotNull(dep.getExclusions());
-        assertEquals(1, dep.getExclusions().size());
+        assertThat(dep.getExclusions()).hasSize(1);
         DependencyExclusion exc = dep.getExclusions().iterator().next();
 
-        assertEquals("e-gid", exc.getGroupId());
-        assertEquals("e-aid", exc.getArtifactId());
+        assertThat(exc.getGroupId()).isEqualTo("e-gid");
+        assertThat(exc.getArtifactId()).isEqualTo("e-aid");
 
-        assertNotNull(pm.getSkippedArtifacts());
-        assertEquals(1, pm.getSkippedArtifacts().size());
+        assertThat(pm.getSkippedArtifacts()).hasSize(1);
         SkippedArtifactMetadata skip = pm.getSkippedArtifacts().iterator().next();
 
-        assertEquals("s-gid", skip.getGroupId());
-        assertEquals("s-aid", skip.getArtifactId());
-        assertEquals("s-ext", skip.getExtension());
-        assertEquals("s-cla", skip.getClassifier());
+        assertThat(skip.getGroupId()).isEqualTo("s-gid");
+        assertThat(skip.getArtifactId()).isEqualTo("s-aid");
+        assertThat(skip.getExtension()).isEqualTo("s-ext");
+        assertThat(skip.getClassifier()).isEqualTo("s-cla");
     }
 
     @Test
-    public void testSimpleMetadata() {
+    void simpleMetadata() {
         List<String> pathList = List.of("src/test/resources/simple.xml");
         Map<Path, PackageMetadata> map = reader.readMetadata(pathList);
-        assertNotNull(map);
-        assertEquals(1, map.size());
+        assertThat(map).hasSize(1);
 
         PackageMetadata pm = map.values().iterator().next();
         Iterator<ArtifactMetadata> iter = pm.getArtifacts().iterator();
 
-        assertTrue(iter.hasNext());
+        assertThat(iter).hasNext();
         ArtifactMetadata am1 = iter.next();
-        assertNotNull(am1);
+        assertThat(am1).isNotNull();
 
-        assertEquals("org.codehaus.plexus", am1.getGroupId());
-        assertEquals("plexus-ant-factory", am1.getArtifactId());
-        assertEquals("jar", am1.getExtension());
-        assertEquals("", am1.getClassifier());
-        assertEquals("1.0", am1.getVersion());
-        assertEquals("ns", am1.getNamespace());
-        assertEquals("/usr/share/java/plexus/ant-factory-1.0.jar", am1.getPath());
+        assertThat(am1.getGroupId()).isEqualTo("org.codehaus.plexus");
+        assertThat(am1.getArtifactId()).isEqualTo("plexus-ant-factory");
+        assertThat(am1.getExtension()).isEqualTo("jar");
+        assertThat(am1.getClassifier()).isEqualTo("");
+        assertThat(am1.getVersion()).isEqualTo("1.0");
+        assertThat(am1.getNamespace()).isEqualTo("ns");
+        assertThat(am1.getPath()).isEqualTo("/usr/share/java/plexus/ant-factory-1.0.jar");
 
         List<String> compatVersions1 = am1.getCompatVersions();
-        assertEquals(1, compatVersions1.size());
-        assertEquals("1.0", compatVersions1.iterator().next());
+        assertThat(compatVersions1).hasSize(1);
+        assertThat(compatVersions1.iterator().next()).isEqualTo("1.0");
 
-        assertTrue(iter.hasNext());
+        assertThat(iter).hasNext();
         ArtifactMetadata am2 = iter.next();
-        assertNotNull(am2);
+        assertThat(am2).isNotNull();
 
-        assertEquals("org.codehaus.plexus", am2.getGroupId());
-        assertEquals("plexus-ant-factory", am2.getArtifactId());
-        assertEquals("pom", am2.getExtension());
-        assertEquals("", am2.getClassifier());
-        assertEquals("1.0", am2.getVersion());
-        assertEquals("ns", am2.getNamespace());
-        assertEquals("/usr/share/maven-poms/JPP.plexus-ant-factory-1.0.pom", am2.getPath());
+        assertThat(am2.getGroupId()).isEqualTo("org.codehaus.plexus");
+        assertThat(am2.getArtifactId()).isEqualTo("plexus-ant-factory");
+        assertThat(am2.getExtension()).isEqualTo("pom");
+        assertThat(am2.getClassifier()).isEqualTo("");
+        assertThat(am2.getVersion()).isEqualTo("1.0");
+        assertThat(am2.getNamespace()).isEqualTo("ns");
+        assertThat(am2.getPath()).isEqualTo("/usr/share/maven-poms/JPP.plexus-ant-factory-1.0.pom");
 
         List<String> compatVersions2 = am2.getCompatVersions();
-        assertEquals(1, compatVersions2.size());
-        assertEquals("1.0", compatVersions2.iterator().next());
+        assertThat(compatVersions2).hasSize(1);
+        assertThat(compatVersions2.iterator().next()).isEqualTo("1.0");
     }
 }

--- a/xmvn-core/src/test/java/org/fedoraproject/xmvn/metadata/impl/MetadataResolverTest.java
+++ b/xmvn-core/src/test/java/org/fedoraproject/xmvn/metadata/impl/MetadataResolverTest.java
@@ -15,10 +15,7 @@
  */
 package org.fedoraproject.xmvn.metadata.impl;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.List;
@@ -34,11 +31,11 @@ import org.junit.jupiter.api.Test;
 /**
  * @author Mikolaj Izdebski
  */
-public class MetadataResolverTest extends AbstractTest {
+class MetadataResolverTest extends AbstractTest {
     private MetadataResolver metadataResolver;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         metadataResolver = new DefaultMetadataResolver(locator);
     }
 
@@ -48,16 +45,16 @@ public class MetadataResolverTest extends AbstractTest {
      * @throws Exception
      */
     @Test
-    public void testCompatExactVersion() throws Exception {
+    void compatExactVersion() throws Exception {
         List<String> pathList = List.of("src/test/resources/metadata1.xml");
         MetadataResult result = metadataResolver.resolveMetadata(new MetadataRequest(pathList));
 
         Artifact artifact = Artifact.of("gid", "aid", "ext", "cla", "1.2-beta3");
         ArtifactMetadata am = result.getMetadataFor(artifact);
 
-        assertEquals(1, result.getPackageMetadataMap().size());
-        assertNotNull(am);
-        assertEquals("/foo/bar", am.getPath());
+        assertThat(result.getPackageMetadataMap()).hasSize(1);
+        assertThat(am).isNotNull();
+        assertThat(am.getPath()).isEqualTo("/foo/bar");
     }
 
     /**
@@ -66,15 +63,15 @@ public class MetadataResolverTest extends AbstractTest {
      * @throws Exception
      */
     @Test
-    public void testCompatNonExactVersion() throws Exception {
+    void compatNonExactVersion() throws Exception {
         List<String> pathList = List.of("src/test/resources/metadata1.xml");
         MetadataResult result = metadataResolver.resolveMetadata(new MetadataRequest(pathList));
 
         Artifact artifact = Artifact.of("gid", "aid", "ext", "cla", "1.1");
         ArtifactMetadata am = result.getMetadataFor(artifact);
 
-        assertEquals(1, result.getPackageMetadataMap().size());
-        assertNull(am);
+        assertThat(result.getPackageMetadataMap()).hasSize(1);
+        assertThat(am).isNull();
     }
 
     /**
@@ -83,16 +80,16 @@ public class MetadataResolverTest extends AbstractTest {
      * @throws Exception
      */
     @Test
-    public void testNonCompatExactVersion() throws Exception {
+    void nonCompatExactVersion() throws Exception {
         List<String> pathList = List.of("src/test/resources/metadata1-non-compat.xml");
         MetadataResult result = metadataResolver.resolveMetadata(new MetadataRequest(pathList));
 
         Artifact artifact = Artifact.of("gid", "aid", "ext", "cla", Artifact.DEFAULT_VERSION);
         ArtifactMetadata am = result.getMetadataFor(artifact);
 
-        assertEquals(1, result.getPackageMetadataMap().size());
-        assertNotNull(am);
-        assertEquals("/foo/bar", am.getPath());
+        assertThat(result.getPackageMetadataMap()).hasSize(1);
+        assertThat(am).isNotNull();
+        assertThat(am.getPath()).isEqualTo("/foo/bar");
     }
 
     /**
@@ -101,19 +98,19 @@ public class MetadataResolverTest extends AbstractTest {
      * @throws Exception
      */
     @Test
-    public void testNonCompatNonExactVersion() throws Exception {
+    void nonCompatNonExactVersion() throws Exception {
         List<String> pathList = List.of("src/test/resources/metadata1-non-compat.xml");
         MetadataResult result = metadataResolver.resolveMetadata(new MetadataRequest(pathList));
 
         Artifact artifact = Artifact.of("gid", "aid", "ext", "cla", "1.1");
         ArtifactMetadata am = result.getMetadataFor(artifact);
 
-        assertEquals(1, result.getPackageMetadataMap().size());
-        assertNull(am);
+        assertThat(result.getPackageMetadataMap()).hasSize(1);
+        assertThat(am).isNull();
     }
 
     @Test
-    public void testRepositoryListedTwice() throws Exception {
+    void repositoryListedTwice() throws Exception {
         String path = "src/test/resources/simple.xml";
         MetadataRequest request = new MetadataRequest(Arrays.asList(path, path));
         MetadataResult result = metadataResolver.resolveMetadata(request);
@@ -121,13 +118,13 @@ public class MetadataResolverTest extends AbstractTest {
         Artifact artifact = Artifact.of("org.codehaus.plexus", "plexus-ant-factory", "1.0");
         ArtifactMetadata am = result.getMetadataFor(artifact);
 
-        assertEquals(1, result.getPackageMetadataMap().size());
-        assertNotNull(am);
-        assertEquals("/usr/share/java/plexus/ant-factory-1.0.jar", am.getPath());
+        assertThat(result.getPackageMetadataMap()).hasSize(1);
+        assertThat(am).isNotNull();
+        assertThat(am.getPath()).isEqualTo("/usr/share/java/plexus/ant-factory-1.0.jar");
     }
 
     @Test
-    public void testRepositoryListedTwiceDifferentPaths() throws Exception {
+    void repositoryListedTwiceDifferentPaths() throws Exception {
         String path1 = "src/test/resources/simple.xml";
         String path2 = "src/test/../test/resources/simple.xml";
         MetadataRequest request = new MetadataRequest(Arrays.asList(path1, path2));
@@ -136,24 +133,24 @@ public class MetadataResolverTest extends AbstractTest {
         Artifact artifact = Artifact.of("org.codehaus.plexus", "plexus-ant-factory", "1.0");
         ArtifactMetadata am = result.getMetadataFor(artifact);
 
-        assertEquals(2, result.getPackageMetadataMap().size());
-        assertNull(am);
+        assertThat(result.getPackageMetadataMap()).hasSize(2);
+        assertThat(am).isNull();
     }
 
     @Test
-    public void testAllowDuplicates() throws Exception {
+    void allowDuplicates() throws Exception {
         String path1 = "src/test/resources/simple.xml";
         String path2 = "src/test/../test/resources/simple.xml";
         MetadataRequest request = new MetadataRequest(Arrays.asList(path1, path2));
-        assertTrue(request.isIgnoreDuplicates());
+        assertThat(request.isIgnoreDuplicates()).isTrue();
         request.setIgnoreDuplicates(false);
         MetadataResult result = metadataResolver.resolveMetadata(request);
 
         Artifact artifact = Artifact.of("org.codehaus.plexus", "plexus-ant-factory", "1.0");
         ArtifactMetadata am = result.getMetadataFor(artifact);
 
-        assertEquals(2, result.getPackageMetadataMap().size());
-        assertNotNull(am);
-        assertEquals("/usr/share/java/plexus/ant-factory-1.0.jar", am.getPath());
+        assertThat(result.getPackageMetadataMap()).hasSize(2);
+        assertThat(am).isNotNull();
+        assertThat(am.getPath()).isEqualTo("/usr/share/java/plexus/ant-factory-1.0.jar");
     }
 }

--- a/xmvn-core/src/test/java/org/fedoraproject/xmvn/resolver/impl/BasicResolverTest.java
+++ b/xmvn-core/src/test/java/org/fedoraproject/xmvn/resolver/impl/BasicResolverTest.java
@@ -15,12 +15,8 @@
  */
 package org.fedoraproject.xmvn.resolver.impl;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import org.easymock.EasyMock;
 import org.fedoraproject.xmvn.artifact.Artifact;
@@ -45,16 +41,16 @@ import org.xmlunit.assertj3.XmlAssert;
 /**
  * @author Mikolaj Izdebski
  */
-public class BasicResolverTest extends AbstractTest {
+class BasicResolverTest extends AbstractTest {
     /**
      * Test if Plexus can load resolver component.
      *
      * @throws Exception
      */
     @Test
-    public void testComponentLookup() throws Exception {
+    void componentLookup() throws Exception {
         Resolver resolver = getService(Resolver.class);
-        assertNotNull(resolver);
+        assertThat(resolver).isExactlyInstanceOf(DefaultResolver.class);
     }
 
     /**
@@ -63,15 +59,15 @@ public class BasicResolverTest extends AbstractTest {
      * @throws Exception
      */
     @Test
-    public void testConfigurationExistance() throws Exception {
+    void configurationExistance() throws Exception {
         Configurator configurator = getService(Configurator.class);
-        assertNotNull(configurator);
+        assertThat(configurator).isNotNull();
 
         Configuration configuration = configurator.getDefaultConfiguration();
-        assertNotNull(configuration);
+        assertThat(configuration).isNotNull();
 
         ResolverSettings settings = configuration.getResolverSettings();
-        assertNotNull(settings);
+        assertThat(settings).isNotNull();
     }
 
     /**
@@ -80,17 +76,17 @@ public class BasicResolverTest extends AbstractTest {
      * @throws Exception
      */
     @Test
-    public void testResolutionFailure() throws Exception {
+    void resolutionFailure() throws Exception {
         Resolver resolver = getService(Resolver.class);
         ResolutionRequest request =
                 new ResolutionRequest(Artifact.of("some", "nonexistent", "pom", "artifact"));
         ResolutionResult result = resolver.resolve(request);
-        assertNotNull(result);
-        assertNull(result.getArtifactPath());
+        assertThat(result).isNotNull();
+        assertThat(result.getArtifactPath()).isNull();
     }
 
     @Test
-    public void testResolveBasic() throws Exception {
+    void resolveBasic() throws Exception {
         Artifact artifact = Artifact.of("gid", "aid", "ext", "cla", "ver");
         ArtifactMetadata md = new ArtifactMetadata();
         md.setPath("/foo/bar");
@@ -112,14 +108,14 @@ public class BasicResolverTest extends AbstractTest {
         Resolver resolver = new DefaultResolver(mockServiceLocator);
         ResolutionRequest request = new ResolutionRequest(artifact);
         ResolutionResult result = resolver.resolve(request);
-        assertNotNull(result);
-        assertNotNull(result.getArtifactPath());
+        assertThat(result).isNotNull();
+        assertThat(result.getArtifactPath()).isNotNull();
 
         EasyMock.verify(mockMdResult, mockMdResolver, mockServiceLocator);
     }
 
     @Test
-    public void testResolveEmptyPom() throws Exception {
+    void resolveEmptyPom() throws Exception {
         Artifact artifact = Artifact.of("gid", "aid", "pom", "cla", "ver");
         ArtifactMetadata md = new ArtifactMetadata();
         md.setExtension("pom");
@@ -142,9 +138,8 @@ public class BasicResolverTest extends AbstractTest {
         ResolutionRequest request = new ResolutionRequest(artifact);
         request.setPersistentFileNeeded(true);
         ResolutionResult result = resolver.resolve(request);
-        assertNotNull(result);
-        assertNotNull(result.getArtifactPath());
-        assertTrue(Files.isRegularFile(result.getArtifactPath()));
+        assertThat(result).isNotNull();
+        assertThat(result.getArtifactPath()).isRegularFile();
 
         EasyMock.verify(mockMdResult, mockMdResolver, mockServiceLocator);
 
@@ -164,7 +159,7 @@ public class BasicResolverTest extends AbstractTest {
     }
 
     @Test
-    public void testResolvePomWithDep() throws Exception {
+    void resolvePomWithDep() throws Exception {
         Artifact artifact = Artifact.of("gid", "aid", "pom", "cla", "ver");
         ArtifactMetadata md = new ArtifactMetadata();
         md.setExtension("pom");
@@ -197,9 +192,8 @@ public class BasicResolverTest extends AbstractTest {
         ResolutionRequest request = new ResolutionRequest(artifact);
         request.setPersistentFileNeeded(true);
         ResolutionResult result = resolver.resolve(request);
-        assertNotNull(result);
-        assertNotNull(result.getArtifactPath());
-        assertTrue(Files.isRegularFile(result.getArtifactPath()));
+        assertThat(result).isNotNull();
+        assertThat(result.getArtifactPath()).isRegularFile();
 
         EasyMock.verify(mockMdResult, mockMdResolver, mockServiceLocator);
 
@@ -232,7 +226,7 @@ public class BasicResolverTest extends AbstractTest {
     }
 
     @Test
-    public void testMockAgent() throws Exception {
+    void mockAgent() throws Exception {
         Artifact artifact = Artifact.of("gid", "aid", "ext", "cla", "ver");
         Artifact versionlessArtifact =
                 Artifact.of("gid", "aid", "ext", "cla", Artifact.DEFAULT_VERSION);
@@ -266,8 +260,8 @@ public class BasicResolverTest extends AbstractTest {
         resolver.mockAgent = mockAgent;
         ResolutionRequest request = new ResolutionRequest(artifact);
         ResolutionResult result = resolver.resolve(request);
-        assertNotNull(result);
-        assertEquals(Path.of("/foo/bar"), result.getArtifactPath());
+        assertThat(result).isNotNull();
+        assertThat(result.getArtifactPath()).isEqualTo(Path.of("/foo/bar"));
 
         EasyMock.verify(
                 mockAgent, mockMdResult1, mockMdResult2, mockMdResolver, mockServiceLocator);

--- a/xmvn-core/src/test/java/org/fedoraproject/xmvn/resolver/impl/CacheManagerTest.java
+++ b/xmvn-core/src/test/java/org/fedoraproject/xmvn/resolver/impl/CacheManagerTest.java
@@ -15,7 +15,7 @@
  */
 package org.fedoraproject.xmvn.resolver.impl;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
@@ -23,21 +23,19 @@ import org.junit.jupiter.api.Test;
 /**
  * @author Mikolaj Izdebski
  */
-public class CacheManagerTest {
+class CacheManagerTest {
     @Test
-    public void testHashing() {
+    void hashing() {
         CacheManager mgr = new CacheManager();
-        assertEquals(
-                "9F86D081884C7D659A2FEAA0C55AD015A3BF4F1B2B0B822CD15D6C15B0F00A08",
-                mgr.hash("test".getBytes(StandardCharsets.US_ASCII)));
+        assertThat(mgr.hash("test".getBytes(StandardCharsets.US_ASCII)))
+                .isEqualTo("9F86D081884C7D659A2FEAA0C55AD015A3BF4F1B2B0B822CD15D6C15B0F00A08");
     }
 
-    @Test
     /** Test case when the first hex letter is a zero. */
-    public void testHashing2() {
+    @Test
+    void hashing2() {
         CacheManager mgr = new CacheManager();
-        assertEquals(
-                "033C0C34DCC7390311EF0D2CECF963B42A9C6E19D798117A66AF811FB0040A45",
-                mgr.hash("TEST4".getBytes(StandardCharsets.US_ASCII)));
+        assertThat(mgr.hash("TEST4".getBytes(StandardCharsets.US_ASCII)))
+                .isEqualTo("033C0C34DCC7390311EF0D2CECF963B42A9C6E19D798117A66AF811FB0040A45");
     }
 }

--- a/xmvn-core/src/test/java/org/fedoraproject/xmvn/resolver/impl/EffectivePomGeneratorTest.java
+++ b/xmvn-core/src/test/java/org/fedoraproject/xmvn/resolver/impl/EffectivePomGeneratorTest.java
@@ -39,7 +39,7 @@ class EffectivePomGeneratorTest {
     }
 
     @Test
-    public void testEffectivePomSimple() throws Exception {
+    void effectivePomSimple() throws Exception {
         performTest(
                 Artifact.of("gid", "aid", "ver"),
                 List.of(),
@@ -54,7 +54,7 @@ class EffectivePomGeneratorTest {
     }
 
     @Test
-    public void testEffectivePomDependency() throws Exception {
+    void effectivePomDependency() throws Exception {
         Dependency dep = new Dependency();
         dep.setGroupId("dgid");
         dep.setArtifactId("daid");
@@ -87,7 +87,7 @@ class EffectivePomGeneratorTest {
     }
 
     @Test
-    public void testEffectivePomExclusion() throws Exception {
+    void effectivePomExclusion() throws Exception {
         Dependency dep = new Dependency();
         dep.setGroupId("dgid");
         dep.setArtifactId("daid");

--- a/xmvn-core/src/test/java/org/fedoraproject/xmvn/test/AbstractTest.java
+++ b/xmvn-core/src/test/java/org/fedoraproject/xmvn/test/AbstractTest.java
@@ -26,7 +26,7 @@ public class AbstractTest {
     protected DefaultServiceLocator locator;
 
     @BeforeEach
-    public void configureServiceLocator() {
+    void configureServiceLocator() {
         locator = new DefaultServiceLocator();
         locator.addService(Configurator.class, TestConfigurator.class);
     }

--- a/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/AbstractIntegrationTest.java
+++ b/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/AbstractIntegrationTest.java
@@ -15,7 +15,7 @@
  */
 package org.fedoraproject.xmvn.it;
 
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -178,7 +178,7 @@ public abstract class AbstractIntegrationTest {
 
     public void assumeJavaVersionAtLeast(int minVersion) {
         int version = Integer.parseInt(System.getProperty("java.version").replaceAll("\\..*", ""));
-        assumeTrue(version >= minVersion, "Java major version is at least " + minVersion);
+        assumeThat(version).isGreaterThanOrEqualTo(minVersion);
     }
 
     public String getTestProperty(String name) throws IOException {

--- a/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/ArchiveLayoutIntegrationTest.java
+++ b/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/ArchiveLayoutIntegrationTest.java
@@ -15,10 +15,8 @@
  */
 package org.fedoraproject.xmvn.it;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.io.InputStream;
 import java.nio.file.DirectoryStream;
@@ -38,7 +36,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author Mikolaj Izdebski
  */
-public class ArchiveLayoutIntegrationTest extends AbstractIntegrationTest {
+class ArchiveLayoutIntegrationTest extends AbstractIntegrationTest {
     private static class PathExpectation {
         private final String regex;
 
@@ -95,24 +93,23 @@ public class ArchiveLayoutIntegrationTest extends AbstractIntegrationTest {
 
         try (DirectoryStream<Path> ds = Files.newDirectoryStream(dir, nameGlob)) {
             Iterator<Path> it = ds.iterator();
-            assertTrue(it.hasNext());
+            assertThat(it).hasNext();
             Path jarPath = it.next();
-            assertFalse(it.hasNext());
+            assertThat(it.hasNext()).isFalse();
 
             try (InputStream is = Files.newInputStream(jarPath);
                     JarInputStream jis = new JarInputStream(is)) {
                 Manifest mf = jis.getManifest();
-                assertNotNull(mf);
+                assertThat(mf).isNotNull();
 
                 String mainClass = mf.getMainAttributes().getValue("Main-Class");
-                assertNotNull(mainClass);
-                assertTrue(mainClass.startsWith("org.fedoraproject.xmvn.tools."));
+                assertThat(mainClass).startsWith("org.fedoraproject.xmvn.tools.");
 
                 String classPath = mf.getMainAttributes().getValue("Class-Path");
-                assertNotNull(classPath);
+                assertThat(classPath).isNotNull();
                 for (String classPathElement : classPath.split(" +")) {
                     Path depPath = dir.resolve(classPathElement);
-                    assertTrue(Files.isRegularFile(depPath, LinkOption.NOFOLLOW_LINKS));
+                    assertThat(depPath).isRegularFile();
                 }
             }
         }
@@ -143,7 +140,7 @@ public class ArchiveLayoutIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
-    public void testArchiveLayout() throws Exception {
+    void archiveLayout() throws Exception {
         expect(1, 1, "/");
         expect(1, 1, "LICENSE");
         expect(1, 1, "NOTICE");

--- a/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/maven/AbstractMavenIntegrationTest.java
+++ b/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/maven/AbstractMavenIntegrationTest.java
@@ -15,9 +15,7 @@
  */
 package org.fedoraproject.xmvn.it.maven;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -87,13 +85,13 @@ public abstract class AbstractMavenIntegrationTest extends AbstractIntegrationTe
                 PrintStream printTeeStderr = new PrintStream(teeStderr);
                 PrintStream stdout = isPrintOutput() ? printTeeStdout : printSaveStdout;
                 PrintStream stderr = isPrintOutput() ? printTeeStderr : printSaveStderr) {
-            assertEquals(expectFailure ? 1 : 0, run(stdout, stderr, args));
+            assertThat(run(stdout, stderr, args)).isEqualTo(expectFailure ? 1 : 0);
         }
 
-        assertFalse(getStderr().findAny().isPresent());
+        assertThat(getStderr()).isEmpty();
 
         if (expectFailure) {
-            assertTrue(getStdout().anyMatch("[INFO] BUILD FAILURE"::equals));
+            assertThat(getStdout()).contains("[INFO] BUILD FAILURE");
         }
     }
 

--- a/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/maven/basic/EmptyProjectBasicIntegrationTest.java
+++ b/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/maven/basic/EmptyProjectBasicIntegrationTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author Mikolaj Izdebski
  */
-public class EmptyProjectBasicIntegrationTest extends AbstractMavenIntegrationTest {
+class EmptyProjectBasicIntegrationTest extends AbstractMavenIntegrationTest {
     /**
      * This test is supposed to verify that XMvn can be executed and that it can successfully build
      * the most basic project.
@@ -31,7 +31,7 @@ public class EmptyProjectBasicIntegrationTest extends AbstractMavenIntegrationTe
      * @throws Exception
      */
     @Test
-    public void testEmptyProject() throws Exception {
+    void testEmptyProject() throws Exception {
         performTest("verify");
     }
 }

--- a/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/maven/basic/NoGoalsBasicIntegrationTest.java
+++ b/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/maven/basic/NoGoalsBasicIntegrationTest.java
@@ -15,7 +15,7 @@
  */
 package org.fedoraproject.xmvn.it.maven.basic;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.fedoraproject.xmvn.it.maven.AbstractMavenIntegrationTest;
 import org.junit.jupiter.api.Test;
@@ -25,16 +25,13 @@ import org.junit.jupiter.api.Test;
  *
  * @author Mikolaj Izdebski
  */
-public class NoGoalsBasicIntegrationTest extends AbstractMavenIntegrationTest {
+class NoGoalsBasicIntegrationTest extends AbstractMavenIntegrationTest {
     @Test
-    public void testNoGoals() throws Exception {
+    void noGoals() throws Exception {
         expectFailure();
         performTest();
-        assertTrue(
-                getStdout()
-                        .anyMatch(
-                                s ->
-                                        s.startsWith(
-                                                "[ERROR] No goals have been specified for this build.")));
+        assertThat(getStdout())
+                .anyMatch(
+                        s -> s.startsWith("[ERROR] No goals have been specified for this build."));
     }
 }

--- a/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/maven/basic/NoPomBasicIntegrationTest.java
+++ b/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/maven/basic/NoPomBasicIntegrationTest.java
@@ -15,7 +15,7 @@
  */
 package org.fedoraproject.xmvn.it.maven.basic;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.fedoraproject.xmvn.it.maven.AbstractMavenIntegrationTest;
 import org.junit.jupiter.api.Test;
@@ -25,17 +25,16 @@ import org.junit.jupiter.api.Test;
  *
  * @author Mikolaj Izdebski
  */
-public class NoPomBasicIntegrationTest extends AbstractMavenIntegrationTest {
+class NoPomBasicIntegrationTest extends AbstractMavenIntegrationTest {
     @Test
-    public void testNoPom() throws Exception {
+    void noPom() throws Exception {
         expectFailure();
         performTest("validate");
-        assertTrue(
-                getStdout()
-                        .anyMatch(
-                                s ->
-                                        s.startsWith(
-                                                "[ERROR] The goal you specified requires a project to execute "
-                                                        + "but there is no POM in this directory")));
+        assertThat(getStdout())
+                .anyMatch(
+                        s ->
+                                s.startsWith(
+                                        "[ERROR] The goal you specified requires a project to execute "
+                                                + "but there is no POM in this directory"));
     }
 }

--- a/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/maven/basic/PluginAliasBasicIntegrationTest.java
+++ b/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/maven/basic/PluginAliasBasicIntegrationTest.java
@@ -15,9 +15,8 @@
  */
 package org.fedoraproject.xmvn.it.maven.basic;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import org.fedoraproject.xmvn.it.maven.AbstractMavenIntegrationTest;
 import org.junit.jupiter.api.Test;
@@ -27,18 +26,16 @@ import org.junit.jupiter.api.Test;
  *
  * @author Mikolaj Izdebski
  */
-public class PluginAliasBasicIntegrationTest extends AbstractMavenIntegrationTest {
+class PluginAliasBasicIntegrationTest extends AbstractMavenIntegrationTest {
     @Test
-    public void testPluginAlias() throws Exception {
+    void testPluginAlias() throws Exception {
         performTest("process-classes");
-        assertTrue(
-                getStdout()
-                        .anyMatch(
-                                s ->
-                                        s.startsWith(
-                                                "[INFO] --- plexus-component-metadata:1.7.1:generate-metadata (default)")));
-        assertTrue(
-                Files.isRegularFile(Path.of("src/main/resources/META-INF/plexus/components.xml")));
-        assertTrue(Files.isRegularFile(Path.of("component-metadata-test.xml")));
+        assertThat(getStdout())
+                .anyMatch(
+                        s ->
+                                s.startsWith(
+                                        "[INFO] --- plexus-component-metadata:1.7.1:generate-metadata (default)"));
+        assertThat(Path.of("src/main/resources/META-INF/plexus/components.xml")).isRegularFile();
+        assertThat(Path.of("component-metadata-test.xml")).isRegularFile();
     }
 }

--- a/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/maven/basic/PluginBasicIntegrationTest.java
+++ b/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/maven/basic/PluginBasicIntegrationTest.java
@@ -15,9 +15,8 @@
  */
 package org.fedoraproject.xmvn.it.maven.basic;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import org.fedoraproject.xmvn.it.maven.AbstractMavenIntegrationTest;
 import org.junit.jupiter.api.Test;
@@ -27,18 +26,16 @@ import org.junit.jupiter.api.Test;
  *
  * @author Mikolaj Izdebski
  */
-public class PluginBasicIntegrationTest extends AbstractMavenIntegrationTest {
+class PluginBasicIntegrationTest extends AbstractMavenIntegrationTest {
     @Test
-    public void testPlugin() throws Exception {
+    void testPlugin() throws Exception {
         performTest("process-classes");
-        assertTrue(
-                getStdout()
-                        .anyMatch(
-                                s ->
-                                        s.startsWith(
-                                                "[INFO] --- plexus-component-metadata:1.7.1:generate-metadata (default)")));
-        assertTrue(
-                Files.isRegularFile(Path.of("src/main/resources/META-INF/plexus/components.xml")));
-        assertTrue(Files.isRegularFile(Path.of("component-metadata-test.xml")));
+        assertThat(getStdout())
+                .anyMatch(
+                        s ->
+                                s.startsWith(
+                                        "[INFO] --- plexus-component-metadata:1.7.1:generate-metadata (default)"));
+        assertThat(Path.of("src/main/resources/META-INF/plexus/components.xml")).isRegularFile();
+        assertThat(Path.of("component-metadata-test.xml")).isRegularFile();
     }
 }

--- a/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/maven/basic/ToolchainManagerBasicIntegrationTest.java
+++ b/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/maven/basic/ToolchainManagerBasicIntegrationTest.java
@@ -15,7 +15,7 @@
  */
 package org.fedoraproject.xmvn.it.maven.basic;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.fedoraproject.xmvn.it.maven.AbstractMavenIntegrationTest;
 import org.junit.jupiter.api.Test;
@@ -25,24 +25,22 @@ import org.junit.jupiter.api.Test;
  *
  * @author Mikolaj Izdebski
  */
-public class ToolchainManagerBasicIntegrationTest extends AbstractMavenIntegrationTest {
+class ToolchainManagerBasicIntegrationTest extends AbstractMavenIntegrationTest {
     @Test
-    public void testToolchainManager() throws Exception {
+    void testToolchainManager() throws Exception {
         performTest(
                 "-Dmaven.installation.toolchains="
                         + getWorkDir().resolve("toolchains.xml").toString(),
                 "verify");
-        assertTrue(
-                getStdout()
-                        .anyMatch(
-                                s ->
-                                        s.matches(
-                                                "\\[INFO\\] Toolchain in (maven-)?compiler-plugin: JDK\\[/tmp\\]")));
-        assertTrue(
-                getStdout()
-                        .anyMatch(
-                                s ->
-                                        s.matches(
-                                                "\\[INFO\\] Toolchain in (maven-)?surefire-plugin: JDK\\[/tmp\\]")));
+        assertThat(getStdout())
+                .anyMatch(
+                        s ->
+                                s.matches(
+                                        "\\[INFO\\] Toolchain in (maven-)?compiler-plugin: JDK\\[/tmp\\]"));
+        assertThat(getStdout())
+                .anyMatch(
+                        s ->
+                                s.matches(
+                                        "\\[INFO\\] Toolchain in (maven-)?surefire-plugin: JDK\\[/tmp\\]"));
     }
 }

--- a/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/maven/basic/VersionBasicIntegrationTest.java
+++ b/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/maven/basic/VersionBasicIntegrationTest.java
@@ -15,8 +15,7 @@
  */
 package org.fedoraproject.xmvn.it.maven.basic;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.fedoraproject.xmvn.it.maven.AbstractMavenIntegrationTest;
 import org.junit.jupiter.api.Test;
@@ -26,13 +25,13 @@ import org.junit.jupiter.api.Test;
  *
  * @author Mikolaj Izdebski
  */
-public class VersionBasicIntegrationTest extends AbstractMavenIntegrationTest {
+class VersionBasicIntegrationTest extends AbstractMavenIntegrationTest {
     @Test
-    public void testVersion() throws Exception {
+    void version() throws Exception {
         performTest("-v");
-        assertTrue(getStdout().anyMatch(s -> s.contains("Apache Maven")));
-        assertTrue(getStdout().anyMatch(s -> s.equals("Maven home: " + getMavenHome())));
-        assertFalse(
-                getStdout().anyMatch(s -> s.toLowerCase().matches(".*(error|exception|fail).*")));
+        assertThat(getStdout()).anyMatch(s -> s.contains("Apache Maven"));
+        assertThat(getStdout()).anyMatch(s -> s.equals("Maven home: " + getMavenHome()));
+        assertThat(getStdout())
+                .noneMatch(s -> s.toLowerCase().matches(".*(error|exception|fail).*"));
     }
 }

--- a/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/maven/mojo/AbstractMojoIntegrationTest.java
+++ b/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/maven/mojo/AbstractMojoIntegrationTest.java
@@ -15,7 +15,7 @@
  */
 package org.fedoraproject.xmvn.it.maven.mojo;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -36,12 +36,12 @@ import org.junit.jupiter.api.BeforeEach;
  */
 public class AbstractMojoIntegrationTest extends AbstractMavenIntegrationTest {
     @BeforeEach
-    public void addMetadata() throws Exception {
+    void addMetadata() throws Exception {
         PackageMetadata md = new PackageMetadata();
 
         for (String module : Arrays.asList("mojo", "core", "api", "parent")) {
             Path pomPath = Path.of(getTestProperty("xmvn.it.pom." + module));
-            assertTrue(Files.exists(pomPath), pomPath.toString());
+            assertThat(pomPath).exists();
             ArtifactMetadata pomMd = new ArtifactMetadata();
             pomMd.setGroupId("org.fedoraproject.xmvn");
             pomMd.setArtifactId("xmvn-" + module);
@@ -53,7 +53,7 @@ public class AbstractMojoIntegrationTest extends AbstractMavenIntegrationTest {
 
             if (!module.equals("parent")) {
                 Path jarPath = Path.of(getTestProperty("xmvn.it.dep." + module));
-                assertTrue(Files.exists(jarPath));
+                assertThat(jarPath).exists();
                 ArtifactMetadata jarMd = new ArtifactMetadata();
                 jarMd.setGroupId("org.fedoraproject.xmvn");
                 jarMd.setArtifactId("xmvn-" + module);

--- a/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/maven/mojo/install/InstallMojoIntegrationTest.java
+++ b/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/maven/mojo/install/InstallMojoIntegrationTest.java
@@ -15,9 +15,8 @@
  */
 package org.fedoraproject.xmvn.it.maven.mojo.install;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -29,81 +28,81 @@ import org.fedoraproject.xmvn.metadata.ArtifactMetadata;
 import org.fedoraproject.xmvn.metadata.PackageMetadata;
 import org.junit.jupiter.api.Test;
 
-public class InstallMojoIntegrationTest extends AbstractMojoIntegrationTest {
+class InstallMojoIntegrationTest extends AbstractMojoIntegrationTest {
     private static String id(ArtifactMetadata amd) {
         return amd.getArtifactId() + ":" + amd.getClassifier() + ":" + amd.getExtension();
     }
 
     @Test
-    public void testInstallMojo() throws Exception {
+    void testInstallMojo() throws Exception {
         performMojoTest("package", "install");
         Path reactorPath = Path.of(".xmvn-reactor");
-        assertTrue(Files.isRegularFile(reactorPath));
+        assertThat(reactorPath).isRegularFile();
         PackageMetadata pmd = PackageMetadata.readFromXML(reactorPath);
-        assertEquals(6, pmd.getArtifacts().size());
+        assertThat(pmd.getArtifacts()).hasSize(6);
 
         var map = pmd.getArtifacts().stream().collect(Collectors.toMap(amd -> id(amd), amd -> amd));
         List<ArtifactMetadata> sortedList = new ArrayList<>(new TreeMap<>(map).values());
         Iterator<ArtifactMetadata> it = sortedList.iterator();
 
-        assertTrue(it.hasNext());
+        assertThat(it).hasNext();
         ArtifactMetadata aj = it.next();
-        assertEquals("xmvn.it.install.mojo", aj.getGroupId());
-        assertEquals("install-attached", aj.getArtifactId());
-        assertEquals("jar", aj.getExtension());
-        assertEquals("", aj.getClassifier());
-        assertEquals("42", aj.getVersion());
-        assertTrue(Files.isRegularFile(Path.of(aj.getPath())));
-        assertEquals(1, aj.getDependencies().size());
+        assertThat(aj.getGroupId()).isEqualTo("xmvn.it.install.mojo");
+        assertThat(aj.getArtifactId()).isEqualTo("install-attached");
+        assertThat(aj.getExtension()).isEqualTo("jar");
+        assertThat(aj.getClassifier()).isEqualTo("");
+        assertThat(aj.getVersion()).isEqualTo("42");
+        assertThat(Path.of(aj.getPath())).isRegularFile();
+        assertThat(aj.getDependencies()).hasSize(1);
 
-        assertTrue(it.hasNext());
+        assertThat(it).hasNext();
         ArtifactMetadata ap = it.next();
-        assertEquals("xmvn.it.install.mojo", ap.getGroupId());
-        assertEquals("install-attached", ap.getArtifactId());
-        assertEquals("pom", ap.getExtension());
-        assertEquals("", ap.getClassifier());
-        assertEquals("42", ap.getVersion());
-        assertTrue(Files.isRegularFile(Path.of(ap.getPath())));
-        assertEquals(1, ap.getDependencies().size());
+        assertThat(ap.getGroupId()).isEqualTo("xmvn.it.install.mojo");
+        assertThat(ap.getArtifactId()).isEqualTo("install-attached");
+        assertThat(ap.getExtension()).isEqualTo("pom");
+        assertThat(ap.getClassifier()).isEqualTo("");
+        assertThat(ap.getVersion()).isEqualTo("42");
+        assertThat(Path.of(ap.getPath())).isRegularFile();
+        assertThat(ap.getDependencies()).hasSize(1);
 
-        assertTrue(it.hasNext());
+        assertThat(it).hasNext();
         ArtifactMetadata at = it.next();
-        assertEquals("xmvn.it.install.mojo", at.getGroupId());
-        assertEquals("install-attached", at.getArtifactId());
-        assertEquals("jar", at.getExtension());
-        assertEquals("tests", at.getClassifier());
-        assertEquals("42", at.getVersion());
-        assertTrue(Files.isRegularFile(Path.of(at.getPath())));
-        assertEquals(1, at.getDependencies().size());
+        assertThat(at.getGroupId()).isEqualTo("xmvn.it.install.mojo");
+        assertThat(at.getArtifactId()).isEqualTo("install-attached");
+        assertThat(at.getExtension()).isEqualTo("jar");
+        assertThat(at.getClassifier()).isEqualTo("tests");
+        assertThat(at.getVersion()).isEqualTo("42");
+        assertThat(Path.of(at.getPath())).isRegularFile();
+        assertThat(at.getDependencies()).hasSize(1);
 
-        assertTrue(it.hasNext());
+        assertThat(it).hasNext();
         ArtifactMetadata pp = it.next();
-        assertEquals("xmvn.it.install.mojo", pp.getGroupId());
-        assertEquals("install-parent", pp.getArtifactId());
-        assertEquals("pom", pp.getExtension());
-        assertEquals("", pp.getClassifier());
-        assertEquals("42", pp.getVersion());
-        assertTrue(Files.isRegularFile(Path.of(pp.getPath())));
-        assertEquals(0, pp.getDependencies().size());
+        assertThat(pp.getGroupId()).isEqualTo("xmvn.it.install.mojo");
+        assertThat(pp.getArtifactId()).isEqualTo("install-parent");
+        assertThat(pp.getExtension()).isEqualTo("pom");
+        assertThat(pp.getClassifier()).isEqualTo("");
+        assertThat(pp.getVersion()).isEqualTo("42");
+        assertThat(Path.of(pp.getPath())).isRegularFile();
+        assertThat(pp.getDependencies()).isEmpty();
 
-        assertTrue(it.hasNext());
+        assertThat(it).hasNext();
         ArtifactMetadata sj = it.next();
-        assertEquals("xmvn.it.install.mojo", sj.getGroupId());
-        assertEquals("install-simple", sj.getArtifactId());
-        assertEquals("jar", sj.getExtension());
-        assertEquals("", sj.getClassifier());
-        assertEquals("42", sj.getVersion());
-        assertTrue(Files.isRegularFile(Path.of(sj.getPath())));
-        assertEquals(0, sj.getDependencies().size());
+        assertThat(sj.getGroupId()).isEqualTo("xmvn.it.install.mojo");
+        assertThat(sj.getArtifactId()).isEqualTo("install-simple");
+        assertThat(sj.getExtension()).isEqualTo("jar");
+        assertThat(sj.getClassifier()).isEqualTo("");
+        assertThat(sj.getVersion()).isEqualTo("42");
+        assertThat(Path.of(sj.getPath())).isRegularFile();
+        assertThat(sj.getDependencies()).isEmpty();
 
-        assertTrue(it.hasNext());
+        assertThat(it).hasNext();
         ArtifactMetadata sp = it.next();
-        assertEquals("xmvn.it.install.mojo", sp.getGroupId());
-        assertEquals("install-simple", sp.getArtifactId());
-        assertEquals("pom", sp.getExtension());
-        assertEquals("", sp.getClassifier());
-        assertEquals("42", sp.getVersion());
-        assertTrue(Files.isRegularFile(Path.of(sp.getPath())));
-        assertEquals(0, sp.getDependencies().size());
+        assertThat(sp.getGroupId()).isEqualTo("xmvn.it.install.mojo");
+        assertThat(sp.getArtifactId()).isEqualTo("install-simple");
+        assertThat(sp.getExtension()).isEqualTo("pom");
+        assertThat(sp.getClassifier()).isEqualTo("");
+        assertThat(sp.getVersion()).isEqualTo("42");
+        assertThat(Path.of(sp.getPath())).isRegularFile();
+        assertThat(sp.getDependencies()).isEmpty();
     }
 }

--- a/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/tool/AbstractToolIntegrationTest.java
+++ b/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/tool/AbstractToolIntegrationTest.java
@@ -15,8 +15,7 @@
  */
 package org.fedoraproject.xmvn.it.tool;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -57,17 +56,17 @@ public abstract class AbstractToolIntegrationTest extends AbstractIntegrationTes
         }
 
         Path libDir = getMavenHome().resolve("lib").resolve(subDir);
-        assertTrue(Files.isDirectory(libDir, LinkOption.NOFOLLOW_LINKS));
+        assertThat(Files.isDirectory(libDir, LinkOption.NOFOLLOW_LINKS)).isTrue();
         return libDir;
     }
 
     private Path getJar(String tool, String glob) throws Exception {
         try (DirectoryStream<Path> ds = Files.newDirectoryStream(getToolLibDir(tool), glob)) {
             Iterator<Path> it = ds.iterator();
-            assertTrue(it.hasNext(), "JAR not found for glob: " + glob);
+            assertThat(it).as("JAR not found for glob: " + glob).hasNext();
             Path jar = it.next();
-            assertFalse(it.hasNext(), "More than one JAR found for glob: " + glob);
-            assertTrue(Files.isRegularFile(jar, LinkOption.NOFOLLOW_LINKS));
+            assertThat(it.hasNext()).as("More than one JAR found for glob: " + glob).isFalse();
+            assertThat(Files.isRegularFile(jar, LinkOption.NOFOLLOW_LINKS)).isTrue();
             return jar;
         }
     }
@@ -89,7 +88,7 @@ public abstract class AbstractToolIntegrationTest extends AbstractIntegrationTes
         }
         String projectName = jarName.substring(5, 5 + jarName.substring(5).indexOf('-'));
         Path dep = Path.of(getTestProperty("xmvn.it.dep." + projectName));
-        assertTrue(Files.exists(dep, LinkOption.NOFOLLOW_LINKS));
+        assertThat(Files.exists(dep, LinkOption.NOFOLLOW_LINKS)).isTrue();
         return dep;
     }
 

--- a/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/tool/installer/InstallerHelpIntegrationTest.java
+++ b/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/tool/installer/InstallerHelpIntegrationTest.java
@@ -15,9 +15,7 @@
  */
 package org.fedoraproject.xmvn.it.tool.installer;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.fedoraproject.xmvn.it.tool.AbstractToolIntegrationTest;
 import org.junit.jupiter.api.Test;
@@ -27,11 +25,11 @@ import org.junit.jupiter.api.Test;
  *
  * @author Mikolaj Izdebski
  */
-public class InstallerHelpIntegrationTest extends AbstractToolIntegrationTest {
+class InstallerHelpIntegrationTest extends AbstractToolIntegrationTest {
     @Test
-    public void testInstallerHelp() throws Exception {
-        assertEquals(0, invokeTool("xmvn-install", "--help"));
-        assertFalse(getStderr().findAny().isPresent());
-        assertTrue(getStdout().anyMatch(line -> line.startsWith("Usage: xmvn-install")));
+    void installerHelp() throws Exception {
+        assertThat(invokeTool("xmvn-install", "--help")).isEqualTo(0);
+        assertThat(getStderr()).isEmpty();
+        assertThat(getStdout()).anyMatch(line -> line.startsWith("Usage: xmvn-install"));
     }
 }

--- a/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/tool/resolver/ResolveFailIntegrationTest.java
+++ b/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/tool/resolver/ResolveFailIntegrationTest.java
@@ -15,9 +15,7 @@
  */
 package org.fedoraproject.xmvn.it.tool.resolver;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.fedoraproject.xmvn.it.tool.AbstractToolIntegrationTest;
 import org.junit.jupiter.api.Test;
@@ -27,16 +25,12 @@ import org.junit.jupiter.api.Test;
  *
  * @author Mikolaj Izdebski
  */
-public class ResolveFailIntegrationTest extends AbstractToolIntegrationTest {
+class ResolveFailIntegrationTest extends AbstractToolIntegrationTest {
     @Test
-    public void testResolveFail() throws Exception {
-        assertEquals(1, invokeTool("xmvn-resolve", "foobar:xyzzy"));
-        assertTrue(
-                getStderr()
-                        .anyMatch(
-                                s ->
-                                        s.endsWith(
-                                                "Unable to resolve artifact foobar:xyzzy:jar:SYSTEM")));
-        assertFalse(getStdout().findAny().isPresent());
+    void testResolveFail() throws Exception {
+        assertThat(invokeTool("xmvn-resolve", "foobar:xyzzy")).isEqualTo(1);
+        assertThat(getStderr())
+                .anyMatch(s -> s.endsWith("Unable to resolve artifact foobar:xyzzy:jar:SYSTEM"));
+        assertThat(getStdout()).isEmpty();
     }
 }

--- a/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/tool/resolver/ResolveNoneIntegrationTest.java
+++ b/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/tool/resolver/ResolveNoneIntegrationTest.java
@@ -15,8 +15,7 @@
  */
 package org.fedoraproject.xmvn.it.tool.resolver;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.fedoraproject.xmvn.it.tool.AbstractToolIntegrationTest;
 import org.junit.jupiter.api.Test;
@@ -26,11 +25,11 @@ import org.junit.jupiter.api.Test;
  *
  * @author Mikolaj Izdebski
  */
-public class ResolveNoneIntegrationTest extends AbstractToolIntegrationTest {
+class ResolveNoneIntegrationTest extends AbstractToolIntegrationTest {
     @Test
-    public void testResolveNone() throws Exception {
-        assertEquals(0, invokeTool("xmvn-resolve"));
-        assertFalse(getStderr().findAny().isPresent());
-        assertFalse(getStdout().findAny().isPresent());
+    void testResolveNone() throws Exception {
+        assertThat(invokeTool("xmvn-resolve")).isEqualTo(0);
+        assertThat(getStderr()).isEmpty();
+        assertThat(getStdout()).isEmpty();
     }
 }

--- a/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/tool/resolver/ResolveOneIntegrationTest.java
+++ b/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/tool/resolver/ResolveOneIntegrationTest.java
@@ -15,11 +15,8 @@
  */
 package org.fedoraproject.xmvn.it.tool.resolver;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -31,17 +28,17 @@ import org.junit.jupiter.api.Test;
  *
  * @author Mikolaj Izdebski
  */
-public class ResolveOneIntegrationTest extends AbstractToolIntegrationTest {
+class ResolveOneIntegrationTest extends AbstractToolIntegrationTest {
     @Test
-    public void testResolveOne() throws Exception {
-        assertEquals(0, invokeTool("xmvn-resolve", "junit:junit"));
-        assertFalse(getStderr().findAny().isPresent());
+    void testResolveOne() throws Exception {
+        assertThat(invokeTool("xmvn-resolve", "junit:junit")).isEqualTo(0);
+        assertThat(getStderr()).isEmpty();
 
         List<String> out = getStdout().collect(Collectors.toList());
-        assertEquals(1, out.size());
+        assertThat(out).hasSize(1);
 
         Path jar = Path.of(out.iterator().next());
-        assertTrue(jar.endsWith("src/test/resources/empty.jar"));
-        assertTrue(Files.isRegularFile(jar));
+        assertThat(jar).endsWith(Path.of("src/test/resources/empty.jar"));
+        assertThat(jar).isRegularFile();
     }
 }

--- a/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/tool/resolver/ResolveRawNoneIntegrationTest.java
+++ b/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/tool/resolver/ResolveRawNoneIntegrationTest.java
@@ -15,8 +15,7 @@
  */
 package org.fedoraproject.xmvn.it.tool.resolver;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.stream.Collectors;
 import org.fedoraproject.xmvn.it.tool.AbstractToolIntegrationTest;
@@ -28,11 +27,12 @@ import org.xmlunit.assertj3.XmlAssert;
  *
  * @author Mikolaj Izdebski
  */
-public class ResolveRawNoneIntegrationTest extends AbstractToolIntegrationTest {
+class ResolveRawNoneIntegrationTest extends AbstractToolIntegrationTest {
     @Test
-    public void testResolveRawNone() throws Exception {
-        assertEquals(0, invokeToolWithInput("<requests/>", "xmvn-resolve", "--raw-request"));
-        assertFalse(getStderr().findAny().isPresent());
+    void resolveRawNone() throws Exception {
+        assertThat(invokeToolWithInput("<requests/>", "xmvn-resolve", "--raw-request"))
+                .isEqualTo(0);
+        assertThat(getStderr()).isEmpty();
         XmlAssert.assertThat("<results/>")
                 .and(getStdout().collect(Collectors.joining()))
                 .areSimilar();

--- a/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/tool/resolver/ResolveRawNullIntegrationTest.java
+++ b/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/tool/resolver/ResolveRawNullIntegrationTest.java
@@ -15,9 +15,7 @@
  */
 package org.fedoraproject.xmvn.it.tool.resolver;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.fedoraproject.xmvn.it.tool.AbstractToolIntegrationTest;
 import org.junit.jupiter.api.Test;
@@ -27,11 +25,11 @@ import org.junit.jupiter.api.Test;
  *
  * @author Mikolaj Izdebski
  */
-public class ResolveRawNullIntegrationTest extends AbstractToolIntegrationTest {
+class ResolveRawNullIntegrationTest extends AbstractToolIntegrationTest {
     @Test
-    public void testResolveRawNull() throws Exception {
-        assertEquals(2, invokeToolWithInput("", "xmvn-resolve", "--raw-request"));
-        assertTrue(getStderr().findAny().isPresent());
-        assertFalse(getStdout().findAny().isPresent());
+    void resolveRawNull() throws Exception {
+        assertThat(invokeToolWithInput("", "xmvn-resolve", "--raw-request")).isEqualTo(2);
+        assertThat(getStderr()).isNotEmpty();
+        assertThat(getStdout()).isEmpty();
     }
 }

--- a/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/tool/resolver/ResolveRawOneIntegrationTest.java
+++ b/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/tool/resolver/ResolveRawOneIntegrationTest.java
@@ -15,8 +15,7 @@
  */
 package org.fedoraproject.xmvn.it.tool.resolver;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.file.Path;
 import java.util.stream.Collectors;
@@ -29,9 +28,9 @@ import org.xmlunit.assertj3.XmlAssert;
  *
  * @author Mikolaj Izdebski
  */
-public class ResolveRawOneIntegrationTest extends AbstractToolIntegrationTest {
+class ResolveRawOneIntegrationTest extends AbstractToolIntegrationTest {
     @Test
-    public void testResolveRawOne() throws Exception {
+    void testResolveRawOne() throws Exception {
         String input =
                 String.join(
                         "\n",
@@ -50,8 +49,8 @@ public class ResolveRawOneIntegrationTest extends AbstractToolIntegrationTest {
                         "  <providerNeeded><![CDATA[false]]></providerNeeded>",
                         " </request>",
                         "</requests>");
-        assertEquals(0, invokeToolWithInput(input, "xmvn-resolve", "--raw-request"));
-        assertFalse(getStderr().findAny().isPresent());
+        assertThat(invokeToolWithInput(input, "xmvn-resolve", "--raw-request")).isEqualTo(0);
+        assertThat(getStderr()).isEmpty();
         Path absPath =
                 getDependencyDir().resolve("plexus-component-metadata-1.7.1.jar").toRealPath();
         String expectedOutput =

--- a/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/tool/resolver/ResolveRawTrashIntegrationTest.java
+++ b/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/tool/resolver/ResolveRawTrashIntegrationTest.java
@@ -15,9 +15,7 @@
  */
 package org.fedoraproject.xmvn.it.tool.resolver;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.fedoraproject.xmvn.it.tool.AbstractToolIntegrationTest;
 import org.junit.jupiter.api.Test;
@@ -27,11 +25,11 @@ import org.junit.jupiter.api.Test;
  *
  * @author Mikolaj Izdebski
  */
-public class ResolveRawTrashIntegrationTest extends AbstractToolIntegrationTest {
+class ResolveRawTrashIntegrationTest extends AbstractToolIntegrationTest {
     @Test
-    public void testResolveRawTrash() throws Exception {
-        assertEquals(2, invokeToolWithInput("xyzzy", "xmvn-resolve", "--raw-request"));
-        assertTrue(getStderr().findAny().isPresent());
-        assertFalse(getStdout().findAny().isPresent());
+    void resolveRawTrash() throws Exception {
+        assertThat(invokeToolWithInput("xyzzy", "xmvn-resolve", "--raw-request")).isEqualTo(2);
+        assertThat(getStderr()).isNotEmpty();
+        assertThat(getStdout()).isEmpty();
     }
 }

--- a/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/tool/resolver/ResolveRawTwoIntegrationTest.java
+++ b/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/tool/resolver/ResolveRawTwoIntegrationTest.java
@@ -15,8 +15,7 @@
  */
 package org.fedoraproject.xmvn.it.tool.resolver;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.file.Path;
 import java.util.stream.Collectors;
@@ -29,9 +28,9 @@ import org.xmlunit.assertj3.XmlAssert;
  *
  * @author Mikolaj Izdebski
  */
-public class ResolveRawTwoIntegrationTest extends AbstractToolIntegrationTest {
+class ResolveRawTwoIntegrationTest extends AbstractToolIntegrationTest {
     @Test
-    public void testResolveRawTwo() throws Exception {
+    void testResolveRawTwo() throws Exception {
         String input =
                 String.join(
                         "\n",
@@ -49,13 +48,9 @@ public class ResolveRawTwoIntegrationTest extends AbstractToolIntegrationTest {
                         "  </artifact>",
                         " </request>",
                         "</requests>");
-        assertEquals(0, invokeToolWithInput(input, "xmvn-resolve", "--raw-request"));
-        assertTrue(
-                getStderr()
-                        .anyMatch(
-                                s ->
-                                        s.endsWith(
-                                                "Unable to resolve artifact foobar:xyzzy:jar:SYSTEM")));
+        assertThat(invokeToolWithInput(input, "xmvn-resolve", "--raw-request")).isEqualTo(0);
+        assertThat(getStderr())
+                .anyMatch(s -> s.endsWith("Unable to resolve artifact foobar:xyzzy:jar:SYSTEM"));
         Path absPath = getResourcesDir().resolve("empty.jar").toRealPath();
         String expectedOutput =
                 String.join(

--- a/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/tool/resolver/ResolverHelpIntegrationTest.java
+++ b/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/tool/resolver/ResolverHelpIntegrationTest.java
@@ -15,9 +15,7 @@
  */
 package org.fedoraproject.xmvn.it.tool.resolver;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.fedoraproject.xmvn.it.tool.AbstractToolIntegrationTest;
 import org.junit.jupiter.api.Test;
@@ -25,11 +23,11 @@ import org.junit.jupiter.api.Test;
 /**
  * @author Mikolaj Izdebski
  */
-public class ResolverHelpIntegrationTest extends AbstractToolIntegrationTest {
+class ResolverHelpIntegrationTest extends AbstractToolIntegrationTest {
     @Test
-    public void testResolverHelp() throws Exception {
-        assertEquals(0, invokeTool("xmvn-resolve", "--help"));
-        assertFalse(getStderr().findAny().isPresent());
-        assertTrue(getStdout().anyMatch(line -> line.startsWith("Usage: xmvn-resolve")));
+    void resolverHelp() throws Exception {
+        assertThat(invokeTool("xmvn-resolve", "--help")).isEqualTo(0);
+        assertThat(getStderr()).isEmpty();
+        assertThat(getStdout()).anyMatch(line -> line.startsWith("Usage: xmvn-resolve"));
     }
 }

--- a/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/tool/subst/BasicSubstIntegrationTest.java
+++ b/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/tool/subst/BasicSubstIntegrationTest.java
@@ -15,9 +15,7 @@
  */
 package org.fedoraproject.xmvn.it.tool.subst;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -33,7 +31,7 @@ import org.junit.jupiter.api.io.TempDir;
 /**
  * @author Mikolaj Izdebski
  */
-public class BasicSubstIntegrationTest extends AbstractToolIntegrationTest {
+class BasicSubstIntegrationTest extends AbstractToolIntegrationTest {
 
     @TempDir private Path tempDir;
 
@@ -53,7 +51,7 @@ public class BasicSubstIntegrationTest extends AbstractToolIntegrationTest {
     }
 
     @Test
-    public void testSubst() throws Exception {
+    void testSubst() throws Exception {
         Path jarA = writeJar("A");
         Path jarB =
                 writeJar(
@@ -68,37 +66,30 @@ public class BasicSubstIntegrationTest extends AbstractToolIntegrationTest {
                         "JavaPackages-ArtifactId=xyzzy",
                         "JavaPackages-Version=42");
 
-        assertEquals(0, invokeTool("xmvn-subst", tempDir.toString()));
-        assertFalse(getStdout().findAny().isPresent());
+        assertThat(invokeTool("xmvn-subst", tempDir.toString())).isEqualTo(0);
+        assertThat(getStdout()).isEmpty();
 
-        assertTrue(Files.isRegularFile(jarA, LinkOption.NOFOLLOW_LINKS));
-        assertTrue(Files.isSymbolicLink(jarB));
-        assertTrue(Files.isRegularFile(jarC, LinkOption.NOFOLLOW_LINKS));
+        assertThat(Files.isRegularFile(jarA, LinkOption.NOFOLLOW_LINKS)).isTrue();
+        assertThat(jarB).isSymbolicLink();
+        assertThat(Files.isRegularFile(jarC, LinkOption.NOFOLLOW_LINKS)).isTrue();
 
-        assertTrue(
-                getStderr()
-                        .anyMatch(
-                                s ->
-                                        s.equals(
-                                                "Skipping file "
-                                                        + jarA
-                                                        + ": No artifact definition found")));
-        assertTrue(
-                getStderr()
-                        .anyMatch(
-                                s ->
-                                        s.equals(
-                                                "Linked "
-                                                        + jarB
-                                                        + " to "
-                                                        + getResourcesDir().resolve("empty.jar"))));
-        assertTrue(
-                getStderr()
-                        .anyMatch(
-                                s ->
-                                        s.equals(
-                                                "WARNING: Skipping file "
-                                                        + jarC
-                                                        + ": Artifact foo:xyzzy:jar:42 not found in repository")));
+        assertThat(getStderr())
+                .anyMatch(
+                        s -> s.equals("Skipping file " + jarA + ": No artifact definition found"));
+        assertThat(getStderr())
+                .anyMatch(
+                        s ->
+                                s.equals(
+                                        "Linked "
+                                                + jarB
+                                                + " to "
+                                                + getResourcesDir().resolve("empty.jar")));
+        assertThat(getStderr())
+                .anyMatch(
+                        s ->
+                                s.equals(
+                                        "WARNING: Skipping file "
+                                                + jarC
+                                                + ": Artifact foo:xyzzy:jar:42 not found in repository"));
     }
 }

--- a/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/tool/subst/SubstHelpIntegrationTest.java
+++ b/xmvn-it/src/test/java/org/fedoraproject/xmvn/it/tool/subst/SubstHelpIntegrationTest.java
@@ -15,9 +15,7 @@
  */
 package org.fedoraproject.xmvn.it.tool.subst;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.fedoraproject.xmvn.it.tool.AbstractToolIntegrationTest;
 import org.junit.jupiter.api.Test;
@@ -25,11 +23,11 @@ import org.junit.jupiter.api.Test;
 /**
  * @author Mikolaj Izdebski
  */
-public class SubstHelpIntegrationTest extends AbstractToolIntegrationTest {
+class SubstHelpIntegrationTest extends AbstractToolIntegrationTest {
     @Test
-    public void testSubstHelp() throws Exception {
-        assertEquals(0, invokeTool("xmvn-subst", "--help"));
-        assertFalse(getStderr().findAny().isPresent());
-        assertTrue(getStdout().anyMatch(line -> line.startsWith("Usage: xmvn-subst")));
+    void substHelp() throws Exception {
+        assertThat(invokeTool("xmvn-subst", "--help")).isEqualTo(0);
+        assertThat(getStderr()).isEmpty();
+        assertThat(getStdout()).anyMatch(line -> line.startsWith("Usage: xmvn-subst"));
     }
 }

--- a/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/repository/impl/CustomRepositoryTest.java
+++ b/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/repository/impl/CustomRepositoryTest.java
@@ -15,8 +15,7 @@
  */
 package org.fedoraproject.xmvn.repository.impl;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.easymock.EasyMock;
 import org.fedoraproject.xmvn.config.Configuration;
@@ -27,14 +26,14 @@ import org.junit.jupiter.api.Test;
 /**
  * @author Mikolaj Izdebski
  */
-public class CustomRepositoryTest {
+class CustomRepositoryTest {
     /**
      * Test if simple (non-composite) repository configuration works as expected.
      *
      * @throws Exception
      */
     @Test
-    public void testCustomRepository() throws Exception {
+    void customRepository() throws Exception {
         Configuration configuration = new Configuration();
         Repository repository = new Repository();
         repository.setId("test123");
@@ -52,7 +51,6 @@ public class CustomRepositoryTest {
         org.fedoraproject.xmvn.repository.Repository repo =
                 repoConfigurator.configureRepository("test123");
         EasyMock.verify(configurator);
-        assertNotNull(repo);
-        assertTrue(repo instanceof MyRepository);
+        assertThat(repo).isExactlyInstanceOf(MyRepository.class);
     }
 }

--- a/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/repository/impl/JppRepositoryTest.java
+++ b/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/repository/impl/JppRepositoryTest.java
@@ -15,8 +15,7 @@
  */
 package org.fedoraproject.xmvn.repository.impl;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.file.Path;
 import org.easymock.EasyMock;
@@ -31,9 +30,9 @@ import org.junit.jupiter.api.Test;
 /**
  * @author Mikolaj Izdebski
  */
-public class JppRepositoryTest {
+class JppRepositoryTest {
     @Test
-    public void testJppRepository() throws Exception {
+    void jppRepository() throws Exception {
         Configuration configuration = new Configuration();
         Repository repository = new Repository();
         repository.setId("test123");
@@ -48,18 +47,16 @@ public class JppRepositoryTest {
         org.fedoraproject.xmvn.repository.Repository repo =
                 repoConfigurator.configureRepository("test123");
         EasyMock.verify(configurator);
-        assertNotNull(repo);
+        assertThat(repo).isNotNull();
 
         Artifact artifact1 = Artifact.of("foo.bar", "the-artifact", "baz", "1.2.3");
         ArtifactContext context1 = new ArtifactContext(artifact1);
-        assertEquals(
-                Path.of("my-target/path/aid-1.2.3.baz"),
-                repo.getPrimaryArtifactPath(artifact1, context1, "my-target/path/aid"));
+        assertThat(repo.getPrimaryArtifactPath(artifact1, context1, "my-target/path/aid"))
+                .isEqualTo(Path.of("my-target/path/aid-1.2.3.baz"));
 
         Artifact artifact2 = artifact1.withVersion(null);
         ArtifactContext context2 = new ArtifactContext(artifact2);
-        assertEquals(
-                Path.of("my-target/path/aid.baz"),
-                repo.getPrimaryArtifactPath(artifact2, context2, "my-target/path/aid"));
+        assertThat(repo.getPrimaryArtifactPath(artifact2, context2, "my-target/path/aid"))
+                .isEqualTo(Path.of("my-target/path/aid.baz"));
     }
 }

--- a/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/repository/impl/LayoutTest.java
+++ b/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/repository/impl/LayoutTest.java
@@ -15,9 +15,7 @@
  */
 package org.fedoraproject.xmvn.repository.impl;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.file.Path;
 import java.util.Properties;
@@ -30,18 +28,18 @@ import org.junit.jupiter.api.Test;
 /**
  * @author Mikolaj Izdebski
  */
-public class LayoutTest {
+class LayoutTest {
     private Repository mavenRepository;
 
     private Repository jppRepository;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         mavenRepository = new MavenRepositoryFactory().getInstance(null, new Properties(), null);
         jppRepository = new JppRepositoryFactory().getInstance(null, new Properties(), null);
 
-        assertNotNull(mavenRepository);
-        assertNotNull(jppRepository);
+        assertThat(mavenRepository).isNotNull();
+        assertThat(jppRepository).isNotNull();
     }
 
     private void testPaths(Repository repository, Artifact artifact, String expected) {
@@ -51,11 +49,10 @@ public class LayoutTest {
                         artifact, context, artifact.getGroupId() + "/" + artifact.getArtifactId());
 
         if (expected == null) {
-            assertNull(repoPath);
+            assertThat(repoPath).isNull();
         } else {
-            assertNotNull(repoPath);
-            assertNotNull(repoPath);
-            assertEquals(expected, repoPath.toString());
+            assertThat(repoPath).isNotNull();
+            assertThat(repoPath.toString()).isEqualTo(expected);
         }
     }
 
@@ -65,7 +62,7 @@ public class LayoutTest {
      * @throws Exception
      */
     @Test
-    public void testLayouts() throws Exception {
+    void layouts() throws Exception {
         Artifact artifact =
                 Artifact.of("an-example.artifact:used-FOR42.testing:ext-ens.ion:blah-1.2.3-foo");
 
@@ -90,7 +87,7 @@ public class LayoutTest {
      * @throws Exception
      */
     @Test
-    public void testJppPrefixes() throws Exception {
+    void jppPrefixes() throws Exception {
         Artifact artifact1 = Artifact.of("JPP:testing:abc:1.2.3");
         Artifact artifact2 = Artifact.of("JPP/group:testing:abc:1.2.3");
         Artifact artifact3 = Artifact.of("JPP-group:testing:abc:1.2.3");

--- a/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/repository/impl/MavenRepositoryTest.java
+++ b/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/repository/impl/MavenRepositoryTest.java
@@ -15,9 +15,7 @@
  */
 package org.fedoraproject.xmvn.repository.impl;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.file.Path;
 import org.easymock.EasyMock;
@@ -32,9 +30,9 @@ import org.junit.jupiter.api.Test;
 /**
  * @author Mikolaj Izdebski
  */
-public class MavenRepositoryTest {
+class MavenRepositoryTest {
     @Test
-    public void testMavenRepository() throws Exception {
+    void mavenRepository() throws Exception {
         Configuration configuration = new Configuration();
         Repository repository = new Repository();
         repository.setId("test123");
@@ -48,17 +46,16 @@ public class MavenRepositoryTest {
         RepositoryConfigurator repoConfigurator = new DefaultRepositoryConfigurator(configurator);
         org.fedoraproject.xmvn.repository.Repository repo =
                 repoConfigurator.configureRepository("test123");
-        assertNotNull(repo);
+        assertThat(repo).isNotNull();
         EasyMock.verify(configurator);
 
         Artifact artifact1 = Artifact.of("foo.bar:the-artifact:baz:1.2.3");
         ArtifactContext context = new ArtifactContext(artifact1);
-        assertEquals(
-                Path.of("foo/bar/the-artifact/1.2.3/the-artifact-1.2.3.baz"),
-                repo.getPrimaryArtifactPath(artifact1, context, "IGNORE-ME"));
+        assertThat(repo.getPrimaryArtifactPath(artifact1, context, "IGNORE-ME"))
+                .isEqualTo(Path.of("foo/bar/the-artifact/1.2.3/the-artifact-1.2.3.baz"));
 
         Artifact artifact2 = artifact1.withVersion(null);
         ArtifactContext context2 = new ArtifactContext(artifact2);
-        assertNull(repo.getPrimaryArtifactPath(artifact2, context2, "IGNORE-ME"));
+        assertThat(repo.getPrimaryArtifactPath(artifact2, context2, "IGNORE-ME")).isNull();
     }
 }

--- a/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/repository/impl/MyRepository.java
+++ b/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/repository/impl/MyRepository.java
@@ -15,7 +15,7 @@
  */
 package org.fedoraproject.xmvn.repository.impl;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.nio.file.Path;
 import java.util.Set;

--- a/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/repository/impl/MyRepositoryFactory.java
+++ b/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/repository/impl/MyRepositoryFactory.java
@@ -15,10 +15,8 @@
  */
 package org.fedoraproject.xmvn.repository.impl;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.Properties;
 import org.fedoraproject.xmvn.repository.Repository;
@@ -30,9 +28,9 @@ import org.w3c.dom.Element;
 public class MyRepositoryFactory implements RepositoryFactory {
     @Override
     public Repository getInstance(Element filter, Properties properties, Element configuration) {
-        assertNotNull(properties);
-        assertEquals("bar", properties.get("foo"));
-        assertNull(properties.get("baz"));
+        assertThat(properties).isNotNull();
+        assertThat(properties.get("foo")).isEqualTo("bar");
+        assertThat(properties.get("baz")).isNull();
 
         return new MyRepository();
     }

--- a/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/tools/install/JarUtilsTest.java
+++ b/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/tools/install/JarUtilsTest.java
@@ -15,20 +15,15 @@
  */
 package org.fedoraproject.xmvn.tools.install;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.FileOutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.PosixFilePermission;
-import java.util.Arrays;
 import java.util.jar.Attributes;
 import java.util.jar.JarInputStream;
 import java.util.jar.Manifest;
@@ -40,11 +35,11 @@ import org.junit.jupiter.api.Test;
 /**
  * @author Mikolaj Izdebski
  */
-public class JarUtilsTest {
+class JarUtilsTest {
     private Path workDir;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         workDir = Path.of("target/test-work");
         Files.createDirectories(workDir);
     }
@@ -63,16 +58,16 @@ public class JarUtilsTest {
 
         try (JarInputStream jis = new JarInputStream(Files.newInputStream(testJar))) {
             Manifest mf = jis.getManifest();
-            assertNotNull(mf);
+            assertThat(mf).isNotNull();
 
             Attributes attr = mf.getMainAttributes();
-            assertNotNull(attr);
+            assertThat(attr).isNotNull();
 
-            assertEquals("org.apache.maven", attr.getValue("JavaPackages-GroupId"));
-            assertEquals("maven-model", attr.getValue("JavaPackages-ArtifactId"));
-            assertEquals("xsd", attr.getValue("JavaPackages-Extension"));
-            assertEquals("model", attr.getValue("JavaPackages-Classifier"));
-            assertEquals("2.2.1", attr.getValue("JavaPackages-Version"));
+            assertThat(attr.getValue("JavaPackages-GroupId")).isEqualTo("org.apache.maven");
+            assertThat(attr.getValue("JavaPackages-ArtifactId")).isEqualTo("maven-model");
+            assertThat(attr.getValue("JavaPackages-Extension")).isEqualTo("xsd");
+            assertThat(attr.getValue("JavaPackages-Classifier")).isEqualTo("model");
+            assertThat(attr.getValue("JavaPackages-Version")).isEqualTo("2.2.1");
         }
     }
 
@@ -82,7 +77,7 @@ public class JarUtilsTest {
      * @throws Exception
      */
     @Test
-    public void testManifestInjection() throws Exception {
+    void manifestInjection() throws Exception {
         testManifestInjectionInto("manifest.jar");
     }
 
@@ -92,7 +87,7 @@ public class JarUtilsTest {
      * @throws Exception
      */
     @Test
-    public void testManifestInjectionNoJarSuffix() throws Exception {
+    void manifestInjectionNoJarSuffix() throws Exception {
         testManifestInjectionInto("foo");
     }
 
@@ -102,7 +97,7 @@ public class JarUtilsTest {
      * @throws Exception
      */
     @Test
-    public void testManifestInjectionHiddenFilename() throws Exception {
+    void manifestInjectionHiddenFilename() throws Exception {
         testManifestInjectionInto(".f");
     }
 
@@ -113,7 +108,7 @@ public class JarUtilsTest {
      * @throws Exception
      */
     @Test
-    public void testManifestInjectionLateManifest() throws Exception {
+    void manifestInjectionLateManifest() throws Exception {
         Path testResource = Path.of("src/test/resources/late-manifest.jar");
         Path testJar = workDir.resolve("manifest.jar");
         Files.copy(
@@ -127,16 +122,16 @@ public class JarUtilsTest {
 
         try (JarInputStream jis = new JarInputStream(Files.newInputStream(testJar))) {
             Manifest mf = jis.getManifest();
-            assertNotNull(mf);
+            assertThat(mf).isNotNull();
 
             Attributes attr = mf.getMainAttributes();
-            assertNotNull(attr);
+            assertThat(attr).isNotNull();
 
-            assertEquals("org.apache.maven", attr.getValue("JavaPackages-GroupId"));
-            assertEquals("maven-model", attr.getValue("JavaPackages-ArtifactId"));
-            assertEquals("xsd", attr.getValue("JavaPackages-Extension"));
-            assertEquals("model", attr.getValue("JavaPackages-Classifier"));
-            assertEquals("2.2.1", attr.getValue("JavaPackages-Version"));
+            assertThat(attr.getValue("JavaPackages-GroupId")).isEqualTo("org.apache.maven");
+            assertThat(attr.getValue("JavaPackages-ArtifactId")).isEqualTo("maven-model");
+            assertThat(attr.getValue("JavaPackages-Extension")).isEqualTo("xsd");
+            assertThat(attr.getValue("JavaPackages-Classifier")).isEqualTo("model");
+            assertThat(attr.getValue("JavaPackages-Version")).isEqualTo("2.2.1");
         }
     }
 
@@ -147,7 +142,7 @@ public class JarUtilsTest {
      * @throws Exception
      */
     @Test
-    public void testManifestInjectionRecompressionCausesSizeMismatch() throws Exception {
+    void manifestInjectionRecompressionCausesSizeMismatch() throws Exception {
         Path testResource = Path.of("src/test/resources/recompression-size.jar");
         Path testJar = workDir.resolve("manifest.jar");
         Files.copy(
@@ -162,14 +157,15 @@ public class JarUtilsTest {
 
         try (JarInputStream jis = new JarInputStream(Files.newInputStream(testJar))) {
             Manifest mf = jis.getManifest();
-            assertNotNull(mf);
+            assertThat(mf).isNotNull();
 
             Attributes attr = mf.getMainAttributes();
-            assertNotNull(attr);
+            assertThat(attr).isNotNull();
 
-            assertEquals("org.eclipse.osgi", attr.getValue("JavaPackages-GroupId"));
-            assertEquals("osgi.compatibility.state", attr.getValue("JavaPackages-ArtifactId"));
-            assertEquals("1.1.0.v20180409-1212", attr.getValue("JavaPackages-Version"));
+            assertThat(attr.getValue("JavaPackages-GroupId")).isEqualTo("org.eclipse.osgi");
+            assertThat(attr.getValue("JavaPackages-ArtifactId"))
+                    .isEqualTo("osgi.compatibility.state");
+            assertThat(attr.getValue("JavaPackages-Version")).isEqualTo("1.1.0.v20180409-1212");
         }
     }
 
@@ -179,7 +175,7 @@ public class JarUtilsTest {
      * @throws Exception
      */
     @Test
-    public void testManifestInjectionDuplicateManifest() throws Exception {
+    void manifestInjectionDuplicateManifest() throws Exception {
         Path testResource = Path.of("src/test/resources/duplicate-manifest.jar");
         Path testJar = workDir.resolve("manifest.jar");
         Files.copy(
@@ -193,16 +189,16 @@ public class JarUtilsTest {
 
         try (JarInputStream jis = new JarInputStream(Files.newInputStream(testJar))) {
             Manifest mf = jis.getManifest();
-            assertNotNull(mf);
+            assertThat(mf).isNotNull();
 
             Attributes attr = mf.getMainAttributes();
-            assertNotNull(attr);
+            assertThat(attr).isNotNull();
 
-            assertEquals("org.apache.maven", attr.getValue("JavaPackages-GroupId"));
-            assertEquals("maven-model", attr.getValue("JavaPackages-ArtifactId"));
-            assertEquals("xsd", attr.getValue("JavaPackages-Extension"));
-            assertEquals("model", attr.getValue("JavaPackages-Classifier"));
-            assertEquals("2.2.1", attr.getValue("JavaPackages-Version"));
+            assertThat(attr.getValue("JavaPackages-GroupId")).isEqualTo("org.apache.maven");
+            assertThat(attr.getValue("JavaPackages-ArtifactId")).isEqualTo("maven-model");
+            assertThat(attr.getValue("JavaPackages-Extension")).isEqualTo("xsd");
+            assertThat(attr.getValue("JavaPackages-Classifier")).isEqualTo("model");
+            assertThat(attr.getValue("JavaPackages-Version")).isEqualTo("2.2.1");
         }
     }
 
@@ -213,7 +209,7 @@ public class JarUtilsTest {
      * @throws Exception
      */
     @Test
-    public void testManifestInjectionDefaults() throws Exception {
+    void manifestInjectionDefaults() throws Exception {
         Path testResource = Path.of("src/test/resources/example.jar");
         Path testJar = workDir.resolve("manifest-defaults.jar");
         Files.copy(
@@ -227,16 +223,16 @@ public class JarUtilsTest {
 
         try (JarInputStream jis = new JarInputStream(Files.newInputStream(testJar))) {
             Manifest mf = jis.getManifest();
-            assertNotNull(mf);
+            assertThat(mf).isNotNull();
 
             Attributes attr = mf.getMainAttributes();
-            assertNotNull(attr);
+            assertThat(attr).isNotNull();
 
-            assertEquals("xpp3", attr.getValue("JavaPackages-GroupId"));
-            assertEquals("xpp3_xpath", attr.getValue("JavaPackages-ArtifactId"));
-            assertEquals(null, attr.getValue("JavaPackages-Extension"));
-            assertEquals(null, attr.getValue("JavaPackages-Classifier"));
-            assertEquals(null, attr.getValue("JavaPackages-Version"));
+            assertThat(attr.getValue("JavaPackages-GroupId")).isEqualTo("xpp3");
+            assertThat(attr.getValue("JavaPackages-ArtifactId")).isEqualTo("xpp3_xpath");
+            assertThat(attr.getValue("JavaPackages-Extension")).isNull();
+            assertThat(attr.getValue("JavaPackages-Classifier")).isNull();
+            assertThat(attr.getValue("JavaPackages-Version")).isNull();
         }
     }
 
@@ -246,7 +242,7 @@ public class JarUtilsTest {
      * @throws Exception
      */
     @Test
-    public void testManifestInjectionSanePermissions() throws Exception {
+    void manifestInjectionSanePermissions() throws Exception {
         Path testResource = Path.of("src/test/resources/example.jar");
         Path testJar = workDir.resolve("manifest.jar");
         Files.copy(
@@ -255,15 +251,14 @@ public class JarUtilsTest {
                 StandardCopyOption.COPY_ATTRIBUTES,
                 StandardCopyOption.REPLACE_EXISTING);
 
-        assumeTrue(
-                Files.getPosixFilePermissions(testJar).contains(PosixFilePermission.OTHERS_READ),
-                "sane umask");
+        assumeThat(Files.getPosixFilePermissions(testJar))
+                .contains(PosixFilePermission.OTHERS_READ);
 
         Artifact artifact = Artifact.of("org.apache.maven", "maven-model", "xsd", "model", "2.2.1");
         JarUtils.injectManifest(testJar, artifact);
 
-        assertTrue(
-                Files.getPosixFilePermissions(testJar).contains(PosixFilePermission.OTHERS_READ));
+        assertThat(Files.getPosixFilePermissions(testJar))
+                .contains(PosixFilePermission.OTHERS_READ);
     }
 
     /**
@@ -272,19 +267,19 @@ public class JarUtilsTest {
      * @throws Exception
      */
     @Test
-    public void testNativeCodeDetection() throws Exception {
+    void nativeCodeDetection() throws Exception {
         Path plainJarPath = Path.of("src/test/resources/example.jar");
         Path nativeCodeJarPath = Path.of("src/test/resources/native-code.jar");
         Path nativeMethodJarPath = Path.of("src/test/resources/native-method.jar");
 
-        assertFalse(JarUtils.usesNativeCode(plainJarPath));
-        assertFalse(JarUtils.containsNativeCode(plainJarPath));
+        assertThat(JarUtils.usesNativeCode(plainJarPath)).isFalse();
+        assertThat(JarUtils.containsNativeCode(plainJarPath)).isFalse();
 
-        assertFalse(JarUtils.usesNativeCode(nativeCodeJarPath));
-        assertTrue(JarUtils.containsNativeCode(nativeCodeJarPath));
+        assertThat(JarUtils.usesNativeCode(nativeCodeJarPath)).isFalse();
+        assertThat(JarUtils.containsNativeCode(nativeCodeJarPath)).isTrue();
 
-        assertTrue(JarUtils.usesNativeCode(nativeMethodJarPath));
-        assertFalse(JarUtils.containsNativeCode(nativeMethodJarPath));
+        assertThat(JarUtils.usesNativeCode(nativeMethodJarPath)).isTrue();
+        assertThat(JarUtils.containsNativeCode(nativeMethodJarPath)).isFalse();
     }
 
     /**
@@ -293,7 +288,7 @@ public class JarUtilsTest {
      * @throws Exception
      */
     @Test
-    public void testInvalidJar() throws Exception {
+    void invalidJar() throws Exception {
         Path testResource = Path.of("src/test/resources/invalid.jar");
         Path testJar = workDir.resolve("invalid.jar");
         Files.copy(
@@ -305,12 +300,10 @@ public class JarUtilsTest {
         Artifact artifact = Artifact.of("foo", "bar");
         JarUtils.injectManifest(testJar, artifact);
 
-        byte[] testJarContent = Files.readAllBytes(testJar);
-        byte[] testResourceContent = Files.readAllBytes(testResource);
-        assertTrue(Arrays.equals(testJarContent, testResourceContent));
+        assertThat(testJar).hasSameBinaryContentAs(testResource);
 
-        assertFalse(JarUtils.usesNativeCode(testResource));
-        assertFalse(JarUtils.containsNativeCode(testResource));
+        assertThat(JarUtils.usesNativeCode(testResource)).isFalse();
+        assertThat(JarUtils.containsNativeCode(testResource)).isFalse();
     }
 
     /**
@@ -319,7 +312,7 @@ public class JarUtilsTest {
      * @throws Exception
      */
     @Test
-    public void testSameINode() throws Exception {
+    void sameINode() throws Exception {
         Path testResource = Path.of("src/test/resources/example.jar");
         Path testJar = workDir.resolve("manifest.jar");
         Files.copy(
@@ -336,7 +329,7 @@ public class JarUtilsTest {
 
         long newInode = (Long) Files.getAttribute(testJar, "unix:ino");
 
-        assertEquals(oldInode, newInode, "Different manifest I-node after injection");
+        assertThat(newInode).as("Different manifest I-node after injection").isEqualTo(oldInode);
     }
 
     /**
@@ -346,7 +339,7 @@ public class JarUtilsTest {
      * @throws Exception
      */
     @Test
-    public void testBackupDeletion() throws Exception {
+    void backupDeletion() throws Exception {
         Path testResource = Path.of("src/test/resources/example.jar");
         Path testJar = workDir.resolve("manifest.jar");
         Files.copy(
@@ -360,7 +353,7 @@ public class JarUtilsTest {
         Path backupPath = JarUtils.getBackupNameOf(testJar);
         Files.deleteIfExists(backupPath);
         JarUtils.injectManifest(testJar, artifact);
-        assertFalse(Files.exists(backupPath));
+        assertThat(backupPath).doesNotExist();
     }
 
     /**
@@ -370,7 +363,7 @@ public class JarUtilsTest {
      * @throws Exception
      */
     @Test
-    public void testBackupOnFailure() throws Exception {
+    void backupOnFailure() throws Exception {
         Path testResource = Path.of("src/test/resources/example.jar");
         Path testJar = workDir.resolve("manifest.jar");
         Files.copy(
@@ -386,22 +379,10 @@ public class JarUtilsTest {
         Path backupPath = JarUtils.getBackupNameOf(testJar);
         Files.deleteIfExists(backupPath);
 
-        byte[] content = Files.readAllBytes(testJar);
-
-        Exception ex =
-                assertThrows(Exception.class, () -> JarUtils.injectManifest(testJar, artifact));
-
-        assertTrue(
-                ex.getMessage().contains(backupPath.toString()),
-                "An exception thrown when injecting manifest does not mention stored backup file");
-        assertTrue(Files.exists(backupPath));
-
-        byte[] backupContent = Files.readAllBytes(backupPath);
-
-        assertArrayEquals(
-                content,
-                backupContent,
-                "Content of the backup file is different from the content of the original file");
+        assertThatExceptionOfType(Exception.class)
+                .isThrownBy(() -> JarUtils.injectManifest(testJar, artifact))
+                .withMessageContaining(backupPath.toString());
+        assertThat(backupPath).hasSameBinaryContentAs(testResource);
 
         Files.copy(
                 testResource,
@@ -414,12 +395,10 @@ public class JarUtilsTest {
             os.write(0);
         }
 
-        assertThrows(Exception.class, () -> JarUtils.injectManifest(testJar, artifact));
+        assertThatExceptionOfType(Exception.class)
+                .isThrownBy(() -> JarUtils.injectManifest(testJar, artifact));
 
-        assertArrayEquals(
-                backupContent,
-                Files.readAllBytes(backupPath),
-                "Backup file content was overwritten after an unsuccessful injection");
+        assertThat(backupPath).hasSameBinaryContentAs(testResource);
 
         EasyMock.verify(artifact);
 
@@ -432,7 +411,7 @@ public class JarUtilsTest {
      * @throws Exception
      */
     @Test
-    public void testFailWhenBachupPresent() throws Exception {
+    void failWhenBachupPresent() throws Exception {
         Path testResource = Path.of("src/test/resources/example.jar");
         Path testJar = workDir.resolve("manifest.jar");
         Files.copy(
@@ -448,10 +427,8 @@ public class JarUtilsTest {
         Files.createFile(backupPath);
 
         try {
-            assertThrows(
-                    Exception.class,
-                    () -> JarUtils.injectManifest(testJar, artifact),
-                    "Expected failure because the the backup file already exists");
+            assertThatExceptionOfType(Exception.class)
+                    .isThrownBy(() -> JarUtils.injectManifest(testJar, artifact));
         } finally {
             Files.delete(backupPath);
         }
@@ -464,7 +441,7 @@ public class JarUtilsTest {
      * @throws Exception
      */
     @Test
-    public void testManifestInjectionReproducible() throws Exception {
+    void manifestInjectionReproducible() throws Exception {
         Path testResource = Path.of("src/test/resources/example.jar");
         Path testJar1 = workDir.resolve("reproducible1.jar");
         Path testJar2 = workDir.resolve("reproducible2.jar");
@@ -485,8 +462,6 @@ public class JarUtilsTest {
         Thread.sleep(3000); // ZIP time granularity is 2 seconds
         JarUtils.injectManifest(testJar2, artifact);
 
-        byte[] bytes1 = Files.readAllBytes(testJar1);
-        byte[] bytes2 = Files.readAllBytes(testJar2);
-        assertArrayEquals(bytes1, bytes2);
+        assertThat(testJar1).hasSameBinaryContentAs(testJar2);
     }
 }

--- a/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/tools/install/condition/BooleanExpressionTest.java
+++ b/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/tools/install/condition/BooleanExpressionTest.java
@@ -15,9 +15,7 @@
  */
 package org.fedoraproject.xmvn.tools.install.condition;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -29,30 +27,30 @@ import org.junit.jupiter.api.Test;
 /**
  * @author Mikolaj Izdebski
  */
-public class BooleanExpressionTest {
+class BooleanExpressionTest {
     @Test
-    public void testBasicExpressions() {
+    void basicExpressions() {
         Artifact artifact = Artifact.of("foo", "bar");
         ArtifactContext context = new ArtifactContext(artifact);
 
         BooleanExpression trueExpression = new BooleanLiteral(true);
-        assertTrue(trueExpression.getValue(context));
+        assertThat(trueExpression.getValue(context)).isTrue();
 
         BooleanExpression falseExpression = new BooleanLiteral(false);
-        assertFalse(falseExpression.getValue(context));
+        assertThat(falseExpression.getValue(context)).isFalse();
 
         BooleanExpression andExpression = new And(Arrays.asList(trueExpression, falseExpression));
-        assertFalse(andExpression.getValue(context));
+        assertThat(andExpression.getValue(context)).isFalse();
 
         BooleanExpression orExpression = new Or(Arrays.asList(trueExpression, falseExpression));
-        assertTrue(orExpression.getValue(context));
+        assertThat(orExpression.getValue(context)).isTrue();
 
         BooleanExpression xorExpression = new Xor(Arrays.asList(trueExpression, falseExpression));
-        assertTrue(xorExpression.getValue(context));
+        assertThat(xorExpression.getValue(context)).isTrue();
     }
 
     @Test
-    public void testProperties() {
+    void properties() {
         Map<String, String> properties = new LinkedHashMap<>();
         properties.put("foo", "bar");
         properties.put("baz", "");
@@ -60,21 +58,21 @@ public class BooleanExpressionTest {
         ArtifactContext context = new ArtifactContext(artifact, properties);
 
         StringExpression fooProperty = new Property("foo");
-        assertEquals("bar", fooProperty.getValue(context));
+        assertThat(fooProperty.getValue(context)).isEqualTo("bar");
 
         StringExpression bazProperty = new Property("baz");
-        assertEquals("", bazProperty.getValue(context));
+        assertThat(bazProperty.getValue(context)).isEmpty();
 
         StringExpression xyzzyProperty = new Property("xyzzy");
-        assertEquals(null, xyzzyProperty.getValue(context));
+        assertThat(xyzzyProperty.getValue(context)).isNull();
 
         BooleanExpression fooDefined = new Defined("foo");
-        assertTrue(fooDefined.getValue(context));
+        assertThat(fooDefined.getValue(context)).isTrue();
 
         BooleanExpression bazDefined = new Defined("baz");
-        assertTrue(bazDefined.getValue(context));
+        assertThat(bazDefined.getValue(context)).isTrue();
 
         BooleanExpression xyzzyDefined = new Defined("xyzzy");
-        assertFalse(xyzzyDefined.getValue(context));
+        assertThat(xyzzyDefined.getValue(context)).isFalse();
     }
 }

--- a/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/tools/install/condition/ConditionTest.java
+++ b/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/tools/install/condition/ConditionTest.java
@@ -15,9 +15,8 @@
  */
 package org.fedoraproject.xmvn.tools.install.condition;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.io.StringReader;
 import java.util.Collections;
@@ -32,13 +31,13 @@ import org.xml.sax.InputSource;
 /**
  * @author Mikolaj Izdebski
  */
-public class ConditionTest {
+class ConditionTest {
     private ArtifactContext context1;
 
     private ArtifactContext context2;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         context1 =
                 new ArtifactContext(
                         Artifact.of("some-gid", "the-aid", "zip", "xyzzy", "1.2.3"),
@@ -63,10 +62,10 @@ public class ConditionTest {
      * @throws Exception
      */
     @Test
-    public void testNullCondition() throws Exception {
+    void nullCondition() throws Exception {
         Condition cond = new Condition(null);
-        assertTrue(cond.getValue(context1));
-        assertTrue(cond.getValue(context2));
+        assertThat(cond.getValue(context1)).isTrue();
+        assertThat(cond.getValue(context2)).isTrue();
     }
 
     /**
@@ -75,7 +74,7 @@ public class ConditionTest {
      * @throws Exception
      */
     @Test
-    public void testBasicCondition() throws Exception {
+    void basicCondition() throws Exception {
         String xml =
                 """
                 <filter>
@@ -105,8 +104,8 @@ public class ConditionTest {
                 """;
 
         Condition cond = new Condition(buildDom(xml));
-        assertTrue(cond.getValue(context1));
-        assertFalse(cond.getValue(context2));
+        assertThat(cond.getValue(context1)).isTrue();
+        assertThat(cond.getValue(context2)).isFalse();
     }
 
     /**
@@ -115,7 +114,7 @@ public class ConditionTest {
      * @throws Exception
      */
     @Test
-    public void testTernaryOperators() throws Exception {
+    void ternaryOperators() throws Exception {
         String xml =
                 """
                 <filter>
@@ -136,8 +135,8 @@ public class ConditionTest {
                  """;
 
         Condition cond = new Condition(buildDom(xml));
-        assertTrue(cond.getValue(context1));
-        assertTrue(cond.getValue(context2));
+        assertThat(cond.getValue(context1)).isTrue();
+        assertThat(cond.getValue(context2)).isTrue();
     }
 
     /**
@@ -146,7 +145,7 @@ public class ConditionTest {
      * @throws Exception
      */
     @Test
-    public void testSyntaxError() throws Exception {
+    void syntaxError() throws Exception {
         String xml =
                 """
                 <filter>
@@ -160,9 +159,9 @@ public class ConditionTest {
 
         try {
             new Condition(buildDom(xml));
-            fail();
+            fail("");
         } catch (RuntimeException e) {
-            assertTrue(e.getMessage().contains("unknown XML node name: hello"));
+            assertThat(e).hasMessageContaining("unknown XML node name: hello");
         }
     }
 }

--- a/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/tools/install/impl/AbstractFileTest.java
+++ b/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/tools/install/impl/AbstractFileTest.java
@@ -15,13 +15,8 @@
  */
 package org.fedoraproject.xmvn.tools.install.impl;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import org.fedoraproject.xmvn.tools.install.File;
 
@@ -45,11 +40,5 @@ public abstract class AbstractFileTest extends AbstractInstallerTest {
         } finally {
             files.clear();
         }
-    }
-
-    void assertFilesEqual(Path expected, Path actual) throws IOException {
-        byte[] expectedContent = Files.readAllBytes(expected);
-        byte[] actualContent = Files.readAllBytes(actual);
-        assertTrue(Arrays.equals(expectedContent, actualContent));
     }
 }

--- a/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/tools/install/impl/AbstractInstallerTest.java
+++ b/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/tools/install/impl/AbstractInstallerTest.java
@@ -15,9 +15,7 @@
  */
 package org.fedoraproject.xmvn.tools.install.impl;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -26,8 +24,7 @@ import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
+import java.util.Arrays;
 import java.util.List;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -44,11 +41,8 @@ import org.xmlunit.assertj3.XmlAssert;
  */
 public abstract class AbstractInstallerTest {
     protected Path workdir;
-
     protected Path installRoot;
-
     protected Path descriptorRoot;
-
     protected final List<String> descriptors = new ArrayList<>();
 
     @BeforeEach
@@ -82,39 +76,11 @@ public abstract class AbstractInstallerTest {
     protected void assertDirectoryStructure(Path root, String... expected) throws Exception {
         List<String> actualList = new ArrayList<>();
         Files.walkFileTree(root, new FileSystemWalker(root, actualList));
-        assertEqualsImpl(actualList, "directory structure", expected);
+        assertThat(actualList).containsExactlyInAnyOrderElementsOf(Arrays.asList(expected));
     }
 
     protected void assertDescriptorEquals(String... expected) {
-        assertEqualsImpl(descriptors, "file descriptor", expected);
-    }
-
-    private void assertEqualsImpl(List<String> actualList, String what, String... expected) {
-        List<String> expectedList = new ArrayList<>();
-        for (String string : expected) expectedList.add(string);
-
-        Collections.sort(expectedList);
-        Collections.sort(actualList);
-
-        try {
-            Iterator<String> expectedIterator = expectedList.iterator();
-            Iterator<String> actualIterator = actualList.iterator();
-
-            while (expectedIterator.hasNext() && actualIterator.hasNext()) {
-                assertEquals(expectedIterator.next(), actualIterator.next());
-            }
-
-            assertFalse(expectedIterator.hasNext());
-            assertFalse(actualIterator.hasNext());
-        } catch (AssertionError e) {
-            System.err.println("EXPECTED " + what + ":");
-            for (String string : expectedList) System.err.println("  " + string);
-
-            System.err.println("ACTUAL " + what + ":");
-            for (String string : actualList) System.err.println("  " + string);
-
-            throw e;
-        }
+        assertThat(descriptors).containsExactlyInAnyOrder(expected);
     }
 
     protected Path getResource(String name) {
@@ -124,7 +90,7 @@ public abstract class AbstractInstallerTest {
     protected void assertDescriptorEquals(Path mfiles, String... expected) throws IOException {
         List<String> lines = Files.readAllLines(mfiles, Charset.defaultCharset());
 
-        assertEqualsImpl(lines, "descriptor", expected);
+        assertThat(lines).containsExactlyInAnyOrderElementsOf(Arrays.asList(expected));
     }
 
     protected void assertDescriptorEquals(Package pkg, String... expected) throws IOException {
@@ -134,7 +100,7 @@ public abstract class AbstractInstallerTest {
     }
 
     protected void assertMetadataEqual(Path expected, Path actual) throws Exception {
-        assertTrue(Files.isRegularFile(actual));
+        assertThat(actual).isRegularFile();
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         DocumentBuilder builder = factory.newDocumentBuilder();
         Document expectedXml = builder.parse(expected.toString());

--- a/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/tools/install/impl/ArtifactInstallerTest.java
+++ b/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/tools/install/impl/ArtifactInstallerTest.java
@@ -15,18 +15,16 @@
  */
 package org.fedoraproject.xmvn.tools.install.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.isA;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -49,26 +47,26 @@ import org.junit.jupiter.api.Test;
 /**
  * @author Michael Simacek
  */
-public class ArtifactInstallerTest {
+class ArtifactInstallerTest {
     Repository repositoryMock;
 
     private ArtifactInstaller installer;
 
     @BeforeEach
-    public void configure() {
+    void configure() {
         repositoryMock = EasyMock.createMock(Repository.class);
 
         RepositoryConfigurator repoConfigurator =
                 new RepositoryConfigurator() {
                     @Override
                     public Repository configureRepository(String repoId) {
-                        assertEquals("my-install-repo", repoId);
+                        assertThat(repoId).isEqualTo("my-install-repo");
                         return repositoryMock;
                     }
 
                     @Override
                     public Repository configureRepository(String repoId, String namespace) {
-                        fail();
+                        fail("");
                         return null;
                     }
                 };
@@ -106,7 +104,7 @@ public class ArtifactInstallerTest {
     }
 
     @Test
-    public void testInstallation() throws Exception {
+    void installation() throws Exception {
         ArtifactMetadata artifact = createArtifact();
         JavaPackage pkg = new JavaPackage("", "test", Path.of("usr/share/maven-metadata"));
         PackagingRule rule = new PackagingRule();
@@ -114,22 +112,22 @@ public class ArtifactInstallerTest {
         install(pkg, artifact, rule);
 
         PackageMetadata metadata = pkg.getMetadata();
-        assertEquals(1, metadata.getArtifacts().size());
+        assertThat(metadata.getArtifacts()).hasSize(1);
         ArtifactMetadata actualArtifact = metadata.getArtifacts().get(0);
-        assertEquals("ns", actualArtifact.getNamespace());
+        assertThat(actualArtifact.getNamespace()).isEqualTo("ns");
 
-        assertEquals(2, pkg.getFiles().size());
+        assertThat(pkg.getFiles()).hasSize(2);
         Iterator<File> iterator = pkg.getFiles().iterator();
         File file = iterator.next();
         if (file.getTargetPath().equals(Path.of("usr/share/maven-metadata/test.xml"))) {
             file = iterator.next();
         }
-        assertEquals(Path.of("com.example-test"), file.getTargetPath());
-        assertEquals("/com.example-test", artifact.getPath());
+        assertThat(file.getTargetPath()).isEqualTo(Path.of("com.example-test"));
+        assertThat(artifact.getPath()).isEqualTo("/com.example-test");
     }
 
     @Test
-    public void testCompatVersion() throws Exception {
+    void compatVersion() throws Exception {
         ArtifactMetadata artifact = createArtifact();
         JavaPackage pkg = new JavaPackage("", "test", Path.of("usr/share/maven-metadata"));
         PackagingRule rule = new PackagingRule();
@@ -139,15 +137,13 @@ public class ArtifactInstallerTest {
         install(pkg, artifact, rule);
 
         PackageMetadata metadata = pkg.getMetadata();
-        assertEquals(1, metadata.getArtifacts().size());
+        assertThat(metadata.getArtifacts()).hasSize(1);
         ArtifactMetadata actualArtifact = metadata.getArtifacts().get(0);
-        List<String> actualVersions = actualArtifact.getCompatVersions();
-        Collections.sort(actualVersions);
-        assertEquals(Arrays.asList(new String[] {"3", "3.4"}), actualVersions);
+        assertThat(actualArtifact.getCompatVersions()).containsExactlyInAnyOrder("3", "3.4");
     }
 
     @Test
-    public void testAliases() throws Exception {
+    void aliases() throws Exception {
         ArtifactMetadata artifact = createArtifact();
         JavaPackage pkg = new JavaPackage("", "test", Path.of("usr/share/maven-metadata"));
         PackagingRule rule = new PackagingRule();
@@ -168,14 +164,14 @@ public class ArtifactInstallerTest {
         install(pkg, artifact, rule);
 
         PackageMetadata metadata = pkg.getMetadata();
-        assertEquals(1, metadata.getArtifacts().size());
+        assertThat(metadata.getArtifacts()).hasSize(1);
         ArtifactMetadata actualArtifact = metadata.getArtifacts().get(0);
         List<ArtifactAlias> actualAliases = actualArtifact.getAliases();
-        assertEquals(2, actualAliases.size());
-        assertEquals("com.example", actualAliases.get(0).getGroupId());
-        assertEquals("alias1", actualAliases.get(0).getArtifactId());
-        assertEquals("com.example", actualAliases.get(1).getGroupId());
-        assertEquals("alias2", actualAliases.get(1).getArtifactId());
-        assertEquals("war", actualAliases.get(1).getClassifier());
+        assertThat(actualAliases).hasSize(2);
+        assertThat(actualAliases.get(0).getGroupId()).isEqualTo("com.example");
+        assertThat(actualAliases.get(0).getArtifactId()).isEqualTo("alias1");
+        assertThat(actualAliases.get(1).getGroupId()).isEqualTo("com.example");
+        assertThat(actualAliases.get(1).getArtifactId()).isEqualTo("alias2");
+        assertThat(actualAliases.get(1).getClassifier()).isEqualTo("war");
     }
 }

--- a/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/tools/install/impl/DirectoryTest.java
+++ b/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/tools/install/impl/DirectoryTest.java
@@ -15,7 +15,7 @@
  */
 package org.fedoraproject.xmvn.tools.install.impl;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -26,14 +26,14 @@ import org.junit.jupiter.api.Test;
 /**
  * @author Mikolaj Izdebski
  */
-public class DirectoryTest extends AbstractFileTest {
+class DirectoryTest extends AbstractFileTest {
     /**
      * Basic test for directory installation
      *
      * @throws Exception
      */
     @Test
-    public void testSingleDirectoryInstallation() throws Exception {
+    void singleDirectoryInstallation() throws Exception {
         add(new Directory(Path.of("usr/src/sys/kern")));
         performInstallation();
 
@@ -48,7 +48,7 @@ public class DirectoryTest extends AbstractFileTest {
      * @throws Exception
      */
     @Test
-    public void testExistentDirectoryInstallation() throws Exception {
+    void existentDirectoryInstallation() throws Exception {
         add(new Directory(Path.of("etc/sysconfig/java")));
         add(new Directory(Path.of("etc/xmvn")));
         add(new Directory(Path.of("etc")));
@@ -65,10 +65,10 @@ public class DirectoryTest extends AbstractFileTest {
 
     /** Test if directory installation fails if target already exists and is not a directory. */
     @Test
-    public void testExistentTargetFile() throws Exception {
+    void existentTargetFile() throws Exception {
         add(new RegularFile(Path.of("foo/bar"), new byte[0]));
         add(new Directory(Path.of("foo/bar")));
-        assertThrows(IOException.class, this::performInstallation);
+        assertThatExceptionOfType(IOException.class).isThrownBy(this::performInstallation);
     }
 
     /**
@@ -76,15 +76,15 @@ public class DirectoryTest extends AbstractFileTest {
      * and is not a directory.
      */
     @Test
-    public void testDirectoryCOmponentIsAFile() throws Exception {
+    void directoryCOmponentIsAFile() throws Exception {
         add(new RegularFile(Path.of("a/b/c/d"), new byte[0]));
         add(new Directory(Path.of("a/b/c/d/e/f/g/h")));
-        assertThrows(IOException.class, this::performInstallation);
+        assertThatExceptionOfType(IOException.class).isThrownBy(this::performInstallation);
     }
 
     /** Test if custom access mode can be specified. */
     @Test
-    public void testAccessMode() throws Exception {
+    void accessMode() throws Exception {
         add(new Directory(Path.of("foo"), 320));
         performInstallation();
 

--- a/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/tools/install/impl/EffectivePackagingTest.java
+++ b/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/tools/install/impl/EffectivePackagingTest.java
@@ -15,10 +15,7 @@
  */
 package org.fedoraproject.xmvn.tools.install.impl;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import org.fedoraproject.xmvn.config.Artifact;
@@ -29,17 +26,17 @@ import org.junit.jupiter.api.Test;
 /**
  * @author Mikolaj Izdebski
  */
-public class EffectivePackagingTest {
+class EffectivePackagingTest {
     /**
      * Test if multiple rules are correctly aggregated into single effective rule.
      *
      * @throws Exception
      */
     @Test
-    public void testRuleAggregation() throws Exception {
+    void ruleAggregation() throws Exception {
         Configuration configuration = new Configuration();
         List<PackagingRule> artifactManagement = configuration.getArtifactManagement();
-        assertTrue(artifactManagement.isEmpty());
+        assertThat(artifactManagement).isEmpty();
 
         Artifact glob = new Artifact();
         glob.setGroupId("foo");
@@ -61,9 +58,9 @@ public class EffectivePackagingTest {
         PackagingRule effectiveRule =
                 new EffectivePackagingRule(
                         artifactManagement, "foo", "bar", "the=ext", "_my_clasfr", "baz");
-        assertTrue("file1".equals(effectiveRule.getFiles().get(0)));
-        assertTrue("file2".equals(effectiveRule.getFiles().get(1)));
-        assertEquals(effectiveRule.getFiles().size(), 2);
+        assertThat(effectiveRule.getFiles().get(0)).isEqualTo("file1");
+        assertThat(effectiveRule.getFiles().get(1)).isEqualTo("file2");
+        assertThat(effectiveRule.getFiles()).hasSize(2);
     }
 
     /**
@@ -72,10 +69,10 @@ public class EffectivePackagingTest {
      * @throws Exception
      */
     @Test
-    public void testWildcards() throws Exception {
+    void wildcards() throws Exception {
         Configuration configuration = new Configuration();
         List<PackagingRule> artifactManagement = configuration.getArtifactManagement();
-        assertTrue(artifactManagement.isEmpty());
+        assertThat(artifactManagement).isEmpty();
 
         Artifact glob = new Artifact();
         glob.setGroupId("foo*bar");
@@ -90,19 +87,19 @@ public class EffectivePackagingTest {
         PackagingRule effRule1 =
                 new EffectivePackagingRule(
                         artifactManagement, "foo-test-bar", "ipsum-dolor", "jar", "", "1.2.3");
-        assertNotNull(effRule1.getTargetPackage());
-        assertTrue("pkgX".equals(effRule1.getTargetPackage()));
+        assertThat(effRule1.getTargetPackage()).isNotNull();
+        assertThat(effRule1.getTargetPackage()).isEqualTo("pkgX");
 
         PackagingRule effRule2 =
                 new EffectivePackagingRule(
                         artifactManagement, "foobar", "lorem-dolor", "jar", "", "1.2.3");
-        assertNotNull(effRule2.getTargetPackage());
-        assertTrue("pkgX".equals(effRule2.getTargetPackage()));
+        assertThat(effRule2.getTargetPackage()).isNotNull();
+        assertThat(effRule2.getTargetPackage()).isEqualTo("pkgX");
 
         PackagingRule effRule3 =
                 new EffectivePackagingRule(
                         artifactManagement, "foobar", "lorem-dolor", "jar", "", "1.253");
-        assertNull(effRule3.getTargetPackage());
+        assertThat(effRule3.getTargetPackage()).isNull();
     }
 
     /**
@@ -111,10 +108,10 @@ public class EffectivePackagingTest {
      * @throws Exception
      */
     @Test
-    public void testEmptyGlob() throws Exception {
+    void emptyGlob() throws Exception {
         Configuration configuration = new Configuration();
         List<PackagingRule> artifactManagement = configuration.getArtifactManagement();
-        assertTrue(artifactManagement.isEmpty());
+        assertThat(artifactManagement).isEmpty();
 
         PackagingRule rule = new PackagingRule();
         rule.setArtifactGlob(new Artifact());
@@ -124,8 +121,8 @@ public class EffectivePackagingTest {
         PackagingRule effRule1 =
                 new EffectivePackagingRule(
                         artifactManagement, "maven-plugin", "com.example", "jar", "funny", "0.42");
-        assertNotNull(effRule1.getTargetPackage());
-        assertTrue("somePackage".equals(effRule1.getTargetPackage()));
+        assertThat(effRule1.getTargetPackage()).isNotNull();
+        assertThat(effRule1.getTargetPackage()).isEqualTo("somePackage");
     }
 
     /**
@@ -134,10 +131,10 @@ public class EffectivePackagingTest {
      * @throws Exception
      */
     @Test
-    public void testEmptyPattern() throws Exception {
+    void emptyPattern() throws Exception {
         Configuration configuration = new Configuration();
         List<PackagingRule> artifactManagement = configuration.getArtifactManagement();
-        assertTrue(artifactManagement.isEmpty());
+        assertThat(artifactManagement).isEmpty();
 
         Artifact glob = new Artifact();
         glob.setGroupId("");
@@ -153,9 +150,9 @@ public class EffectivePackagingTest {
 
         PackagingRule effectiveRule =
                 new EffectivePackagingRule(artifactManagement, "bar", "baz", "xy", "zzy", "1.2.3");
-        assertNotNull(effectiveRule);
-        assertNotNull(effectiveRule.getTargetPackage());
-        assertTrue("fooBar".equals(effectiveRule.getTargetPackage()));
+        assertThat(effectiveRule).isNotNull();
+        assertThat(effectiveRule.getTargetPackage()).isNotNull();
+        assertThat(effectiveRule.getTargetPackage()).isEqualTo("fooBar");
     }
 
     /**
@@ -164,10 +161,10 @@ public class EffectivePackagingTest {
      * @throws Exception
      */
     @Test
-    public void testSingletonAndSpecificRule() throws Exception {
+    void singletonAndSpecificRule() throws Exception {
         Configuration configuration = new Configuration();
         List<PackagingRule> artifactManagement = configuration.getArtifactManagement();
-        assertTrue(artifactManagement.isEmpty());
+        assertThat(artifactManagement).isEmpty();
 
         Artifact glob1 = new Artifact();
         glob1.setGroupId("");
@@ -190,8 +187,8 @@ public class EffectivePackagingTest {
         PackagingRule effRule =
                 new EffectivePackagingRule(
                         artifactManagement, "org.sonatype.sisu", "sisu-parent", "pom", "", "2.3.0");
-        assertNotNull(effRule.getTargetPackage());
-        assertTrue("parent".equals(effRule.getTargetPackage()));
+        assertThat(effRule.getTargetPackage()).isNotNull();
+        assertThat(effRule.getTargetPackage()).isEqualTo("parent");
     }
 
     /**
@@ -200,10 +197,10 @@ public class EffectivePackagingTest {
      * @throws Exception
      */
     @Test
-    public void testAliases() throws Exception {
+    void aliases() throws Exception {
         Configuration configuration = new Configuration();
         List<PackagingRule> artifactManagement = configuration.getArtifactManagement();
-        assertTrue(artifactManagement.isEmpty());
+        assertThat(artifactManagement).isEmpty();
 
         Artifact glob = new Artifact();
         glob.setGroupId("");
@@ -227,11 +224,11 @@ public class EffectivePackagingTest {
         PackagingRule effRule =
                 new EffectivePackagingRule(artifactManagement, "foo", "bar", "jar", "", "1.2.3");
 
-        assertEquals(effRule.getAliases().size(), 1);
+        assertThat(effRule.getAliases()).hasSize(1);
         Artifact effAlias = effRule.getAliases().iterator().next();
 
-        assertEquals(effAlias.getGroupId(), "foo");
-        assertEquals(effAlias.getArtifactId(), "bar-test");
-        assertEquals(effAlias.getVersion(), "1.2.3");
+        assertThat(effAlias.getGroupId()).isEqualTo("foo");
+        assertThat(effAlias.getArtifactId()).isEqualTo("bar-test");
+        assertThat(effAlias.getVersion()).isEqualTo("1.2.3");
     }
 }

--- a/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/tools/install/impl/InstallationPlanTest.java
+++ b/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/tools/install/impl/InstallationPlanTest.java
@@ -15,11 +15,9 @@
  */
 package org.fedoraproject.xmvn.tools.install.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.fedoraproject.xmvn.tools.install.impl.InstallationPlanLoader.createInstallationPlan;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -32,155 +30,144 @@ import org.junit.jupiter.api.Test;
 /**
  * @author Michael Simacek
  */
-public class InstallationPlanTest {
+class InstallationPlanTest {
     @Test
-    public void testNonexistent() throws Exception {
+    void nonexistent() throws Exception {
         InstallationPlan plan = new InstallationPlan(Path.of("not-there"));
-        assertTrue(plan.getArtifacts().isEmpty());
+        assertThat(plan.getArtifacts()).isEmpty();
     }
 
     @Test
-    public void testValid() throws Exception {
+    void valid() throws Exception {
         InstallationPlan plan = createInstallationPlan("valid.xml");
-        assertFalse(plan.getArtifacts().isEmpty());
-        assertEquals(2, plan.getArtifacts().size());
-        assertEquals("test", plan.getArtifacts().get(0).getArtifactId());
-        assertEquals("test2", plan.getArtifacts().get(1).getArtifactId());
+        assertThat(plan.getArtifacts()).hasSize(2);
+        assertThat(plan.getArtifacts().get(0).getArtifactId()).isEqualTo("test");
+        assertThat(plan.getArtifacts().get(1).getArtifactId()).isEqualTo("test2");
     }
 
     @Test
-    public void testUuid() throws Exception {
+    void uuid() throws Exception {
         createInstallationPlan("uuid.xml");
     }
 
     @Test
-    public void testNamespace() throws Exception {
-        assertThrows(
-                ArtifactInstallationException.class, () -> createInstallationPlan("namespace.xml"));
+    void namespace() throws Exception {
+        assertThatExceptionOfType(ArtifactInstallationException.class)
+                .isThrownBy(() -> createInstallationPlan("namespace.xml"));
     }
 
     @Test
-    public void testAlias() throws Exception {
-        assertThrows(
-                ArtifactInstallationException.class, () -> createInstallationPlan("alias.xml"));
+    void alias() throws Exception {
+        assertThatExceptionOfType(ArtifactInstallationException.class)
+                .isThrownBy(() -> createInstallationPlan("alias.xml"));
     }
 
     @Test
-    public void testCompat() throws Exception {
-        assertThrows(
-                ArtifactInstallationException.class, () -> createInstallationPlan("compat.xml"));
+    void compat() throws Exception {
+        assertThatExceptionOfType(ArtifactInstallationException.class)
+                .isThrownBy(() -> createInstallationPlan("compat.xml"));
     }
 
     @Test
-    public void testNoGroupId() throws Exception {
-        assertThrows(
-                ArtifactInstallationException.class, () -> createInstallationPlan("no-gid.xml"));
+    void noGroupId() throws Exception {
+        assertThatExceptionOfType(ArtifactInstallationException.class)
+                .isThrownBy(() -> createInstallationPlan("no-gid.xml"));
     }
 
     @Test
-    public void testNoArtifactId() throws Exception {
-        assertThrows(
-                ArtifactInstallationException.class, () -> createInstallationPlan("no-aid.xml"));
+    void noArtifactId() throws Exception {
+        assertThatExceptionOfType(ArtifactInstallationException.class)
+                .isThrownBy(() -> createInstallationPlan("no-aid.xml"));
     }
 
     @Test
-    public void testNoVersion() throws Exception {
-        assertThrows(
-                ArtifactInstallationException.class,
-                () -> createInstallationPlan("no-version.xml"));
+    void noVersion() throws Exception {
+        assertThatExceptionOfType(ArtifactInstallationException.class)
+                .isThrownBy(() -> createInstallationPlan("no-version.xml"));
     }
 
     @Test
-    public void testNoFile() throws Exception {
-        assertThrows(
-                ArtifactInstallationException.class, () -> createInstallationPlan("no-file.xml"));
+    void noFile() throws Exception {
+        assertThatExceptionOfType(ArtifactInstallationException.class)
+                .isThrownBy(() -> createInstallationPlan("no-file.xml"));
     }
 
     @Test
-    public void testNonexistenFile() throws Exception {
-        assertThrows(
-                ArtifactInstallationException.class,
-                () -> createInstallationPlan("nonexistent-file.xml"));
+    void nonexistenFile() throws Exception {
+        assertThatExceptionOfType(ArtifactInstallationException.class)
+                .isThrownBy(() -> createInstallationPlan("nonexistent-file.xml"));
     }
 
     @Test
-    public void testNonregularFile() throws Exception {
-        assertThrows(
-                ArtifactInstallationException.class,
-                () -> createInstallationPlan("nonregular-file.xml"));
+    void nonregularFile() throws Exception {
+        assertThatExceptionOfType(ArtifactInstallationException.class)
+                .isThrownBy(() -> createInstallationPlan("nonregular-file.xml"));
     }
 
     @Test
-    public void testNonreadableFile() throws Exception {
-        assertThrows(
-                ArtifactInstallationException.class,
-                () -> createInstallationPlan("nonreadable-file.xml"));
+    void nonreadableFile() throws Exception {
+        assertThatExceptionOfType(ArtifactInstallationException.class)
+                .isThrownBy(() -> createInstallationPlan("nonreadable-file.xml"));
     }
 
     @Test
-    public void testNoArtifactIdDep() throws Exception {
-        assertThrows(
-                ArtifactInstallationException.class,
-                () -> createInstallationPlan("no-aid-dep.xml"));
+    void noArtifactIdDep() throws Exception {
+        assertThatExceptionOfType(ArtifactInstallationException.class)
+                .isThrownBy(() -> createInstallationPlan("no-aid-dep.xml"));
     }
 
     @Test
-    public void testNoGroupIdDep() throws Exception {
-        assertThrows(
-                ArtifactInstallationException.class,
-                () -> createInstallationPlan("no-gid-dep.xml"));
+    void noGroupIdDep() throws Exception {
+        assertThatExceptionOfType(ArtifactInstallationException.class)
+                .isThrownBy(() -> createInstallationPlan("no-gid-dep.xml"));
     }
 
     @Test
-    public void testNoVersionDep() throws Exception {
+    void noVersionDep() throws Exception {
         InstallationPlan plan = createInstallationPlan("no-version-dep.xml");
 
         List<ArtifactMetadata> artifacts = plan.getArtifacts();
-        assertEquals(2, artifacts.size());
+        assertThat(artifacts).hasSize(2);
 
         List<Dependency> dependencies = artifacts.get(1).getDependencies();
-        assertEquals(2, dependencies.size());
+        assertThat(dependencies).hasSize(2);
 
-        assertEquals("4.1", dependencies.get(0).getRequestedVersion());
-        assertEquals(Artifact.DEFAULT_VERSION, dependencies.get(1).getRequestedVersion());
+        assertThat(dependencies.get(0).getRequestedVersion()).isEqualTo("4.1");
+        assertThat(dependencies.get(1).getRequestedVersion()).isEqualTo(Artifact.DEFAULT_VERSION);
     }
 
     @Test
-    public void testNamespaceDep() throws Exception {
-        assertThrows(
-                ArtifactInstallationException.class,
-                () -> createInstallationPlan("namespace-dep.xml"));
+    void namespaceDep() throws Exception {
+        assertThatExceptionOfType(ArtifactInstallationException.class)
+                .isThrownBy(() -> createInstallationPlan("namespace-dep.xml"));
     }
 
     @Test
-    public void testResolvedVersionDep() throws Exception {
-        assertThrows(
-                ArtifactInstallationException.class,
-                () -> createInstallationPlan("resolved-version.xml"));
+    void resolvedVersionDep() throws Exception {
+        assertThatExceptionOfType(ArtifactInstallationException.class)
+                .isThrownBy(() -> createInstallationPlan("resolved-version.xml"));
     }
 
     @Test
-    public void testNoArtifactIdExclusion() throws Exception {
-        assertThrows(
-                ArtifactInstallationException.class,
-                () -> createInstallationPlan("no-aid-excl.xml"));
+    void noArtifactIdExclusion() throws Exception {
+        assertThatExceptionOfType(ArtifactInstallationException.class)
+                .isThrownBy(() -> createInstallationPlan("no-aid-excl.xml"));
     }
 
     @Test
-    public void testNoGroupIdExclusion() throws Exception {
-        assertThrows(
-                ArtifactInstallationException.class,
-                () -> createInstallationPlan("no-gid-excl.xml"));
+    void noGroupIdExclusion() throws Exception {
+        assertThatExceptionOfType(ArtifactInstallationException.class)
+                .isThrownBy(() -> createInstallationPlan("no-gid-excl.xml"));
     }
 
     @Test
-    public void testSkipped() throws Exception {
-        assertThrows(
-                ArtifactInstallationException.class, () -> createInstallationPlan("skipped.xml"));
+    void skipped() throws Exception {
+        assertThatExceptionOfType(ArtifactInstallationException.class)
+                .isThrownBy(() -> createInstallationPlan("skipped.xml"));
     }
 
     @Test
-    public void testMetadataUuid() throws Exception {
+    void metadataUuid() throws Exception {
         createInstallationPlan("metadata-uuid.xml");
     }
 }

--- a/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/tools/install/impl/InstallerTest.java
+++ b/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/tools/install/impl/InstallerTest.java
@@ -15,12 +15,11 @@
  */
 package org.fedoraproject.xmvn.tools.install.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 import static org.fedoraproject.xmvn.tools.install.impl.InstallationPlanLoader.prepareInstallationPlanFile;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.nio.file.Path;
 import org.easymock.EasyMock;
@@ -44,7 +43,7 @@ import org.junit.jupiter.api.Test;
 /**
  * @author Michael Simacek
  */
-public class InstallerTest extends AbstractInstallerTest {
+class InstallerTest extends AbstractInstallerTest {
     private final Configuration config = new Configuration();
 
     private Configurator configuratorMock;
@@ -52,7 +51,7 @@ public class InstallerTest extends AbstractInstallerTest {
     private Resolver resolverMock;
 
     @BeforeEach
-    public void setUpSettings() {
+    void setUpSettings() {
         InstallerSettings settings = new InstallerSettings();
         settings.setMetadataDir("usr/share/maven-metadata");
         config.setInstallerSettings(settings);
@@ -68,8 +67,8 @@ public class InstallerTest extends AbstractInstallerTest {
                 PackagingRule packagingRule,
                 String basePackageName,
                 String repositoryId) {
-            assertEquals("test-pkg", basePackageName);
-            assertEquals("test-repo", repositoryId);
+            assertThat(basePackageName).isEqualTo("test-pkg");
+            assertThat(repositoryId).isEqualTo("test-repo");
             Path path = Path.of("usr/share/java/" + artifactMetadata.getArtifactId() + ".jar");
             File file = new RegularFile(path, Path.of(artifactMetadata.getPath()));
             targetPackage.addFile(file);
@@ -135,7 +134,7 @@ public class InstallerTest extends AbstractInstallerTest {
 
         DefaultInstaller installer =
                 new DefaultInstaller(configuratorMock, resolverMock, installerFactoryMock);
-        assertNotNull(installer);
+        assertThat(installer).isNotNull();
         installer.install(request);
 
         verify(resolverMock, configuratorMock, installerFactoryMock);
@@ -149,7 +148,7 @@ public class InstallerTest extends AbstractInstallerTest {
     }
 
     @Test
-    public void testInstall() throws Exception {
+    void testInstall() throws Exception {
         addEmptyResolutions();
 
         install("valid.xml");
@@ -174,7 +173,7 @@ public class InstallerTest extends AbstractInstallerTest {
     }
 
     @Test
-    public void testResolution() throws Exception {
+    void resolution() throws Exception {
         Path dependencyJar = Path.of("/tmp/bla.jar");
         addResolution("org.apache.lucene:lucene-benchmark:4.1");
         addResolution("org.apache.lucene:lucene-benchmark", "4", "ns", dependencyJar);
@@ -189,7 +188,7 @@ public class InstallerTest extends AbstractInstallerTest {
     }
 
     @Test
-    public void testSelfRequires() throws Exception {
+    void selfRequires() throws Exception {
         install("self-requires.xml");
         assertMetadataEqual(
                 getResource("self-requires-resolved.xml"),
@@ -197,7 +196,7 @@ public class InstallerTest extends AbstractInstallerTest {
     }
 
     @Test
-    public void testSubpackage() throws Exception {
+    void subpackage() throws Exception {
         addEmptyResolutions();
 
         PackagingRule rule = new PackagingRule();

--- a/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/tools/install/impl/JavaPackageTest.java
+++ b/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/tools/install/impl/JavaPackageTest.java
@@ -15,8 +15,7 @@
  */
 package org.fedoraproject.xmvn.tools.install.impl;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.file.Path;
 import org.fedoraproject.xmvn.metadata.ArtifactMetadata;
@@ -28,11 +27,11 @@ import org.junit.jupiter.api.Test;
 /**
  * @author Michael Simacek
  */
-public class JavaPackageTest extends AbstractFileTest {
+class JavaPackageTest extends AbstractFileTest {
     @Test
-    public void testJavaPackage() throws Exception {
+    void javaPackage() throws Exception {
         JavaPackage pkg = new JavaPackage("my-id", "my-pkg", Path.of("usr/share/maven-metadata"));
-        assertEquals("my-id", pkg.getId());
+        assertThat(pkg.getId()).isEqualTo("my-id");
 
         pkg.install(installRoot);
         assertDirectoryStructure(
@@ -45,7 +44,7 @@ public class JavaPackageTest extends AbstractFileTest {
     }
 
     @Test
-    public void testJavaPackageMetadata() throws Exception {
+    void javaPackageMetadata() throws Exception {
         JavaPackage pkg = new JavaPackage("my-id", "my-pkg", Path.of("usr/share/maven-metadata"));
 
         PackageMetadata inputMetadata = pkg.getMetadata();
@@ -56,11 +55,11 @@ public class JavaPackageTest extends AbstractFileTest {
         PackageMetadata actualMetadata =
                 PackageMetadata.readFromXML(
                         installRoot.resolve("usr/share/maven-metadata/my-pkg-my-id.xml"));
-        assertTrue(actualMetadata.getProperties().containsKey("foo"));
+        assertThat(actualMetadata.getProperties()).containsKey("foo");
     }
 
     @Test
-    public void testJavaPackageMetadataSplit() throws Exception {
+    void javaPackageMetadataSplit() throws Exception {
         JavaPackage pkg = new JavaPackage("my-id", "my-pkg", Path.of("usr/share/maven-metadata"));
 
         ArtifactMetadata foo = new ArtifactMetadata();
@@ -85,7 +84,7 @@ public class JavaPackageTest extends AbstractFileTest {
     }
 
     @Test
-    public void testSpacesInFileNames() throws Exception {
+    void spacesInFileNames() throws Exception {
         JavaPackage pkg = new JavaPackage("", "space-test", Path.of("usr/share/maven-metadata"));
         pkg.addFile(
                 new RegularFile(

--- a/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/tools/install/impl/PackageRegistryTest.java
+++ b/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/tools/install/impl/PackageRegistryTest.java
@@ -15,10 +15,7 @@
  */
 package org.fedoraproject.xmvn.tools.install.impl;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.file.Path;
 import java.util.Set;
@@ -31,56 +28,55 @@ import org.junit.jupiter.api.Test;
 /**
  * @author Michael Simacek
  */
-public class PackageRegistryTest {
+class PackageRegistryTest {
     private InstallerSettings settings;
 
     private PackageRegistry registry;
 
     @BeforeEach
-    public void setUpRegistry() {
+    void setUpRegistry() {
         settings = new InstallerSettings();
         settings.setMetadataDir("usr/share/maven-metadata");
         registry = new PackageRegistry(settings, "test-package");
     }
 
     @Test
-    public void testDefaultPackage() {
+    void defaultPackage() {
         JavaPackage pkg1 = registry.getPackageById(null);
         JavaPackage pkg2 = registry.getPackageById(null);
-        assertSame(pkg1, pkg2);
+        assertThat(pkg2).isSameAs(pkg1);
         JavaPackage pkg3 = registry.getPackageById("");
-        assertSame(pkg2, pkg3);
-        assertEquals(1, registry.getPackages().size());
+        assertThat(pkg3).isSameAs(pkg2);
+        assertThat(registry.getPackages()).hasSize(1);
     }
 
     @Test
-    public void testMetadata() throws Exception {
+    void metadata() throws Exception {
         JavaPackage pkg = registry.getPackageById(null);
         Set<File> files = pkg.getFiles();
-        assertEquals(1, files.size());
+        assertThat(files).hasSize(1);
         File metadataFile = files.iterator().next();
-        assertEquals(
-                Path.of("usr/share/maven-metadata/test-package.xml"), metadataFile.getTargetPath());
-        assertNotNull(pkg.getMetadata());
+        assertThat(metadataFile.getTargetPath())
+                .isEqualTo(Path.of("usr/share/maven-metadata/test-package.xml"));
+        assertThat(pkg.getMetadata()).isNotNull();
     }
 
     @Test
-    public void testNonDefault() throws Exception {
+    void nonDefault() throws Exception {
         JavaPackage pkg = registry.getPackageById("subpackage");
         Set<File> files = pkg.getFiles();
-        assertEquals(1, files.size());
+        assertThat(files).hasSize(1);
         File metadataFile = files.iterator().next();
-        assertEquals(
-                Path.of("usr/share/maven-metadata/test-package-subpackage.xml"),
-                metadataFile.getTargetPath());
+        assertThat(metadataFile.getTargetPath())
+                .isEqualTo(Path.of("usr/share/maven-metadata/test-package-subpackage.xml"));
     }
 
     @Test
-    public void testMultiple() throws Exception {
+    void multiple() throws Exception {
         registry.getPackageById(null);
         registry.getPackageById("subpackage");
-        assertEquals(2, registry.getPackages().size());
-        assertNull(registry.getPackageById("__noinstall"));
-        assertEquals(2, registry.getPackages().size());
+        assertThat(registry.getPackages()).hasSize(2);
+        assertThat(registry.getPackageById("__noinstall")).isNull();
+        assertThat(registry.getPackages()).hasSize(2);
     }
 }

--- a/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/tools/install/impl/PackageTest.java
+++ b/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/tools/install/impl/PackageTest.java
@@ -15,9 +15,8 @@
  */
 package org.fedoraproject.xmvn.tools.install.impl;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.nio.file.Path;
 import org.fedoraproject.xmvn.tools.install.Directory;
@@ -30,14 +29,14 @@ import org.junit.jupiter.api.Test;
 /**
  * @author msimacek
  */
-public class PackageTest extends AbstractFileTest {
+class PackageTest extends AbstractFileTest {
     private final Path jar = getResource("example.jar");
 
     @Test
-    public void testSimplePackage() throws Exception {
+    void simplePackage() throws Exception {
         File jarfile = new RegularFile(Path.of("usr/share/java/foobar.jar"), jar);
         Package pkg = new Package("my-id");
-        assertEquals("my-id", pkg.getId());
+        assertThat(pkg.getId()).isEqualTo("my-id");
         pkg.addFile(jarfile);
 
         pkg.install(installRoot);
@@ -47,12 +46,12 @@ public class PackageTest extends AbstractFileTest {
     }
 
     @Test
-    public void testMoreFiles() throws Exception {
+    void moreFiles() throws Exception {
         File dir = new Directory(Path.of("usr/share/java"));
         File jarfile = new RegularFile(Path.of("usr/share/java/foobar.jar"), jar, 0600);
         File link = new SymbolicLink(Path.of("usr/share/java/link.jar"), Path.of("foobar.jar"));
         Package pkg = new Package("my-id");
-        assertEquals("my-id", pkg.getId());
+        assertThat(pkg.getId()).isEqualTo("my-id");
         pkg.addFile(dir);
         pkg.addFile(jarfile);
         pkg.addFile(link);
@@ -72,7 +71,7 @@ public class PackageTest extends AbstractFileTest {
     }
 
     @Test
-    public void testEmpty() throws Exception {
+    void empty() throws Exception {
         Package pkg = new Package("my-id");
 
         pkg.install(installRoot);
@@ -81,22 +80,23 @@ public class PackageTest extends AbstractFileTest {
     }
 
     @Test
-    public void testSameFileTwice() throws Exception {
+    void sameFileTwice() throws Exception {
         File jarfile = new RegularFile(Path.of("usr/share/java/foobar.jar"), jar);
         Package pkg = new Package("my-id");
-        assertEquals("my-id", pkg.getId());
+        assertThat(pkg.getId()).isEqualTo("my-id");
         pkg.addFile(jarfile);
-        assertThrows(IllegalArgumentException.class, () -> pkg.addFile(jarfile));
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> pkg.addFile(jarfile));
     }
 
     @Test
-    public void testEquality() throws Exception {
+    void equality() throws Exception {
         Package pkg = new Package("my-id");
         Package samePkg = new Package("my-id");
         Package anotherPkg = new Package("other-id");
 
-        assertEquals(samePkg, pkg);
-        assertNotEquals(pkg, anotherPkg);
-        assertNotEquals(samePkg, anotherPkg);
+        assertThat(pkg).isEqualTo(samePkg);
+        assertThat(anotherPkg).isNotEqualTo(pkg);
+        assertThat(anotherPkg).isNotEqualTo(samePkg);
     }
 }

--- a/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/tools/install/impl/RegularFileTest.java
+++ b/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/tools/install/impl/RegularFileTest.java
@@ -15,7 +15,8 @@
  */
 package org.fedoraproject.xmvn.tools.install.impl;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -27,9 +28,9 @@ import org.junit.jupiter.api.Test;
 /**
  * @author Michael Simacek
  */
-public class RegularFileTest extends AbstractFileTest {
+class RegularFileTest extends AbstractFileTest {
     @Test
-    public void testFileInstallationFromArray() throws Exception {
+    void fileInstallationFromArray() throws Exception {
         Path jar = getResource("example.jar");
         byte[] content = Files.readAllBytes(jar);
         add(new Directory(Path.of("usr/share/java")));
@@ -37,7 +38,7 @@ public class RegularFileTest extends AbstractFileTest {
         Path root = performInstallation();
         assertDirectoryStructure(
                 "D /usr", "D /usr/share", "D /usr/share/java", "F /usr/share/java/foobar.jar");
-        assertFilesEqual(jar, root.resolve(Path.of("usr/share/java/foobar.jar")));
+        assertThat(root.resolve("usr/share/java/foobar.jar")).hasSameBinaryContentAs(jar);
 
         assertDescriptorEquals(
                 "%attr(0755,root,root) %dir /usr/share/java",
@@ -45,46 +46,46 @@ public class RegularFileTest extends AbstractFileTest {
     }
 
     @Test
-    public void testFileInstallationFromFile() throws Exception {
+    void fileInstallationFromFile() throws Exception {
         Path jar = getResource("example.jar");
         add(new Directory(Path.of("usr/share/java")));
         add(new RegularFile(Path.of("usr/share/java/foobar.jar"), jar));
         Path root = performInstallation();
         assertDirectoryStructure(
                 "D /usr", "D /usr/share", "D /usr/share/java", "F /usr/share/java/foobar.jar");
-        assertFilesEqual(jar, root.resolve(Path.of("usr/share/java/foobar.jar")));
+        assertThat(root.resolve("usr/share/java/foobar.jar")).hasSameBinaryContentAs(jar);
         assertDescriptorEquals(
                 "%attr(0755,root,root) %dir /usr/share/java",
                 "%attr(0644,root,root) /usr/share/java/foobar.jar");
     }
 
     @Test
-    public void testCreateParentDirectory() throws Exception {
+    void createParentDirectory() throws Exception {
         Path jar = getResource("example.jar");
         add(new RegularFile(Path.of("usr/share/java/foobar.jar"), jar));
         Path root = performInstallation();
         assertDirectoryStructure(
                 "D /usr", "D /usr/share", "D /usr/share/java", "F /usr/share/java/foobar.jar");
-        assertFilesEqual(jar, root.resolve(Path.of("usr/share/java/foobar.jar")));
+        assertThat(root.resolve("usr/share/java/foobar.jar")).hasSameBinaryContentAs(jar);
         assertDescriptorEquals("%attr(0644,root,root) /usr/share/java/foobar.jar");
     }
 
     @Test
-    public void testNonexistentFile() throws Exception {
+    void nonexistentFile() throws Exception {
         add(new Directory(Path.of("usr/share/java")));
         add(new RegularFile(Path.of("usr/share/java/foobar.jar"), Path.of("not-here")));
-        assertThrows(IOException.class, this::performInstallation);
+        assertThatExceptionOfType(IOException.class).isThrownBy(this::performInstallation);
     }
 
     @Test
-    public void testAccessMode() throws Exception {
+    void accessMode() throws Exception {
         Path jar = getResource("example.jar");
         add(new Directory(Path.of("usr/share/java")));
         add(new RegularFile(Path.of("usr/share/java/foobar.jar"), jar, 0666));
         Path root = performInstallation();
         assertDirectoryStructure(
                 "D /usr", "D /usr/share", "D /usr/share/java", "F /usr/share/java/foobar.jar");
-        assertFilesEqual(jar, root.resolve(Path.of("usr/share/java/foobar.jar")));
+        assertThat(root.resolve("usr/share/java/foobar.jar")).hasSameBinaryContentAs(jar);
 
         assertDescriptorEquals(
                 "%attr(0755,root,root) %dir /usr/share/java",
@@ -92,26 +93,37 @@ public class RegularFileTest extends AbstractFileTest {
     }
 
     @Test
-    public void testIncorrectMode() throws Exception {
+    void incorrectMode() throws Exception {
         Path jar = getResource("example.jar");
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> add(new RegularFile(Path.of("usr/share/java/foobar.jar"), jar, 01000)));
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(
+                        () ->
+                                add(
+                                        new RegularFile(
+                                                Path.of("usr/share/java/foobar.jar"), jar, 01000)));
     }
 
     @Test
-    public void testNegativeMode() throws Exception {
+    void negativeMode() throws Exception {
         Path jar = getResource("example.jar");
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> add(new RegularFile(Path.of("usr/share/java/foobar.jar"), jar, -0644)));
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(
+                        () ->
+                                add(
+                                        new RegularFile(
+                                                Path.of("usr/share/java/foobar.jar"), jar, -0644)));
     }
 
     @Test
-    public void testAbsoluteTarget() throws Exception {
+    void absoluteTarget() throws Exception {
         Path jar = getResource("example.jar");
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> add(new RegularFile(Path.of("/usr/share/java/foobar.jar"), jar, 01000)));
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(
+                        () ->
+                                add(
+                                        new RegularFile(
+                                                Path.of("/usr/share/java/foobar.jar"),
+                                                jar,
+                                                01000)));
     }
 }

--- a/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/tools/install/impl/SymbolicLinkTest.java
+++ b/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/tools/install/impl/SymbolicLinkTest.java
@@ -15,7 +15,7 @@
  */
 package org.fedoraproject.xmvn.tools.install.impl;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -27,9 +27,9 @@ import org.junit.jupiter.api.Test;
 /**
  * @author Michael Simacek
  */
-public class SymbolicLinkTest extends AbstractFileTest {
+class SymbolicLinkTest extends AbstractFileTest {
     @Test
-    public void testSymlink() throws Exception {
+    void symlink() throws Exception {
         Path jar = getResource("example.jar");
         add(new Directory(Path.of("usr/share/java")));
         add(new RegularFile(Path.of("usr/share/java/foobar.jar"), jar));
@@ -42,7 +42,8 @@ public class SymbolicLinkTest extends AbstractFileTest {
                 "F /usr/share/java/foobar.jar",
                 "L /usr/share/java/link.jar");
         Path link = root.resolve(Path.of("usr/share/java/link.jar"));
-        assertEquals(Files.readSymbolicLink(link), Path.of("foobar.jar"));
+        assertThat(link).isSymbolicLink();
+        assertThat(Files.readSymbolicLink(link)).isEqualTo(Path.of("foobar.jar"));
 
         assertDescriptorEquals(
                 "%attr(0755,root,root) %dir /usr/share/java",

--- a/xmvn-tools/xmvn-resolve/src/test/java/org/fedoraproject/xmvn/tools/resolve/xml/ResolutionRequestUnmarshallerListTest.java
+++ b/xmvn-tools/xmvn-resolve/src/test/java/org/fedoraproject/xmvn/tools/resolve/xml/ResolutionRequestUnmarshallerListTest.java
@@ -15,8 +15,7 @@
  */
 package org.fedoraproject.xmvn.tools.resolve.xml;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.FileInputStream;
 import java.io.InputStream;
@@ -28,124 +27,112 @@ import org.junit.jupiter.api.Test;
 /**
  * @author Marian Koncek
  */
-public class ResolutionRequestUnmarshallerListTest {
+class ResolutionRequestUnmarshallerListTest {
     private final String resourcePath =
             "src/test/resources/org/fedoraproject/xmvn/tools/resolve/xml";
 
     @Test
-    public void testEmptierList() throws Exception {
+    void emptierList() throws Exception {
         try (InputStream is = new FileInputStream(resourcePath + "/test-emptier-list.xml")) {
-            List<ResolutionRequest> list = ResolverDAO.unmarshalRequests(is);
-
-            // The implementation may change. Any of the two results is correct.
-            assertTrue(list == null || list.isEmpty());
+            assertThat(ResolverDAO.unmarshalRequests(is)).isEmpty();
         }
     }
 
     @Test
-    public void testEmptyList() throws Exception {
+    void emptyList() throws Exception {
         try (InputStream is = new FileInputStream(resourcePath + "/test-empty-list.xml")) {
-            List<ResolutionRequest> list = ResolverDAO.unmarshalRequests(is);
-
-            // The implementation may change. Any of the two results is correct.
-            assertTrue(list == null || list.isEmpty());
+            assertThat(ResolverDAO.unmarshalRequests(is)).isEmpty();
         }
     }
 
     @Test
-    public void testFullArtifact() throws Exception {
+    void fullArtifact() throws Exception {
         try (InputStream is = new FileInputStream(resourcePath + "/test-full-artifact.xml")) {
             List<ResolutionRequest> list = ResolverDAO.unmarshalRequests(is);
-
-            assertEquals(1, list.size());
+            assertThat(list).hasSize(1);
 
             Artifact artifact = list.get(0).getArtifact();
 
-            assertEquals("test1", artifact.getArtifactId());
-            assertEquals("test1", artifact.getGroupId());
-            assertEquals("test1", artifact.getExtension());
-            assertEquals("test1", artifact.getClassifier());
-            assertEquals("test1", artifact.getVersion());
-            assertEquals("/dev/null", artifact.getPath().toString());
+            assertThat(artifact.getArtifactId()).isEqualTo("test1");
+            assertThat(artifact.getGroupId()).isEqualTo("test1");
+            assertThat(artifact.getExtension()).isEqualTo("test1");
+            assertThat(artifact.getClassifier()).isEqualTo("test1");
+            assertThat(artifact.getVersion()).isEqualTo("test1");
+            assertThat(artifact.getPath().toString()).isEqualTo("/dev/null");
         }
     }
 
     @Test
-    public void testFullRequests() throws Exception {
+    void fullRequests() throws Exception {
         try (InputStream is = new FileInputStream(resourcePath + "/test-full-requests.xml")) {
             List<ResolutionRequest> list = ResolverDAO.unmarshalRequests(is);
+            assertThat(list).hasSize(6);
 
-            assertEquals(6, list.size());
+            assertThat(list.get(0).isProviderNeeded()).isTrue();
+            assertThat(list.get(0).isPersistentFileNeeded()).isTrue();
 
-            assertEquals(true, list.get(0).isProviderNeeded());
-            assertEquals(true, list.get(0).isPersistentFileNeeded());
+            assertThat(list.get(1).isProviderNeeded()).isFalse();
+            assertThat(list.get(1).isPersistentFileNeeded()).isFalse();
 
-            assertEquals(false, list.get(1).isProviderNeeded());
-            assertEquals(false, list.get(1).isPersistentFileNeeded());
+            assertThat(list.get(2).isProviderNeeded()).isFalse();
+            assertThat(list.get(2).isPersistentFileNeeded()).isTrue();
 
-            assertEquals(false, list.get(2).isProviderNeeded());
-            assertEquals(true, list.get(2).isPersistentFileNeeded());
+            assertThat(list.get(3).isProviderNeeded()).isTrue();
+            assertThat(list.get(3).isPersistentFileNeeded()).isFalse();
 
-            assertEquals(true, list.get(3).isProviderNeeded());
-            assertEquals(false, list.get(3).isPersistentFileNeeded());
+            assertThat(list.get(4).isPersistentFileNeeded()).isTrue();
 
-            assertEquals(true, list.get(4).isPersistentFileNeeded());
-
-            assertEquals(true, list.get(5).isProviderNeeded());
+            assertThat(list.get(5).isProviderNeeded()).isTrue();
         }
     }
 
     @Test
-    public void testIntegrationExample() throws Exception {
+    void integrationExample() throws Exception {
         try (InputStream is = new FileInputStream(resourcePath + "/test-integration-example.xml")) {
             List<ResolutionRequest> list = ResolverDAO.unmarshalRequests(is);
+            assertThat(list).hasSize(2);
 
-            assertEquals(2, list.size());
+            assertThat(list.get(0).getArtifact().getGroupId()).isEqualTo("foobar");
+            assertThat(list.get(0).getArtifact().getArtifactId()).isEqualTo("xyzzy");
 
-            assertEquals("foobar", list.get(0).getArtifact().getGroupId());
-            assertEquals("xyzzy", list.get(0).getArtifact().getArtifactId());
-
-            assertEquals("junit", list.get(1).getArtifact().getArtifactId());
-            assertEquals("junit", list.get(1).getArtifact().getGroupId());
+            assertThat(list.get(1).getArtifact().getArtifactId()).isEqualTo("junit");
+            assertThat(list.get(1).getArtifact().getGroupId()).isEqualTo("junit");
         }
     }
 
     @Test
-    public void testMinimalArtifacts() throws Exception {
+    void minimalArtifacts() throws Exception {
         try (InputStream is = new FileInputStream(resourcePath + "/test-minimal-artifacts.xml")) {
             List<ResolutionRequest> list = ResolverDAO.unmarshalRequests(is);
-
-            assertEquals(5, list.size());
+            assertThat(list).hasSize(5);
 
             int artifactNum = 1;
-
             for (ResolutionRequest rr : list) {
                 Artifact artifact = rr.getArtifact();
-
-                assertEquals("test" + Integer.toString(artifactNum), artifact.getArtifactId());
-                assertEquals("test" + Integer.toString(artifactNum), artifact.getGroupId());
+                assertThat(artifact.getArtifactId()).isEqualTo("test" + artifactNum);
+                assertThat(artifact.getGroupId()).isEqualTo("test" + artifactNum);
                 ++artifactNum;
             }
         }
     }
 
     @Test
-    public void testNestedBrackets() throws Exception {
+    void nestedBrackets() throws Exception {
         try (InputStream is = new FileInputStream(resourcePath + "/test-nested-brackets.xml")) {
             List<ResolutionRequest> list = ResolverDAO.unmarshalRequests(is);
+            assertThat(list).hasSize(1);
 
-            assertEquals(1, list.size());
-
-            assertEquals(false, list.get(0).isPersistentFileNeeded());
+            assertThat(list.get(0).isPersistentFileNeeded()).isFalse();
 
             list.get(0).getArtifact();
             list.get(0).getArtifact().getExtension();
-            assertEquals("jar", list.get(0).getArtifact().getExtension());
-            assertEquals("aliased-component-metadata", list.get(0).getArtifact().getArtifactId());
-            assertEquals("any", list.get(0).getArtifact().getVersion());
-            assertEquals("alias-test", list.get(0).getArtifact().getGroupId());
+            assertThat(list.get(0).getArtifact().getExtension()).isEqualTo("jar");
+            assertThat(list.get(0).getArtifact().getArtifactId())
+                    .isEqualTo("aliased-component-metadata");
+            assertThat(list.get(0).getArtifact().getVersion()).isEqualTo("any");
+            assertThat(list.get(0).getArtifact().getGroupId()).isEqualTo("alias-test");
 
-            assertEquals(false, list.get(0).isProviderNeeded());
+            assertThat(list.get(0).isProviderNeeded()).isFalse();
         }
     }
 }

--- a/xmvn-tools/xmvn-resolve/src/test/java/org/fedoraproject/xmvn/tools/resolve/xml/ResolutionResultMarshallerListTest.java
+++ b/xmvn-tools/xmvn-resolve/src/test/java/org/fedoraproject/xmvn/tools/resolve/xml/ResolutionResultMarshallerListTest.java
@@ -27,9 +27,9 @@ import org.xmlunit.assertj3.XmlAssert;
 /**
  * @author Marian Koncek
  */
-public class ResolutionResultMarshallerListTest {
+class ResolutionResultMarshallerListTest {
     @Test
-    public void testEmpty() throws Exception {
+    void empty() throws Exception {
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         ResolverDAO.marshalResults(bos, List.of());
 
@@ -41,7 +41,7 @@ public class ResolutionResultMarshallerListTest {
     }
 
     @Test
-    public void testMultiple() throws Exception {
+    void multiple() throws Exception {
         List<ResolutionResult> list = new ArrayList<>();
 
         ResolutionResultBean temp;
@@ -93,7 +93,7 @@ public class ResolutionResultMarshallerListTest {
     }
 
     @Test
-    public void testSingle() throws Exception {
+    void single() throws Exception {
         ResolutionResult rr = new ResolutionResultBean().build();
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         ResolverDAO.marshalResults(bos, Arrays.asList(new ResolutionResult[] {rr}));

--- a/xmvn-tools/xmvn-subst/src/test/java/org/fedoraproject/xmvn/tools/subst/ArtifactVisitorTest.java
+++ b/xmvn-tools/xmvn-subst/src/test/java/org/fedoraproject/xmvn/tools/subst/ArtifactVisitorTest.java
@@ -15,7 +15,7 @@
  */
 package org.fedoraproject.xmvn.tools.subst;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.OutputStream;
 import java.nio.file.Files;
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.io.TempDir;
 /**
  * @author Mikolaj Izdebski
  */
-public class ArtifactVisitorTest {
+class ArtifactVisitorTest {
     @TempDir private Path tempDir;
 
     private Path writeJar(String location, String gid, String aid, String ver) throws Exception {
@@ -55,7 +55,7 @@ public class ArtifactVisitorTest {
     }
 
     @Test
-    public void testEmptyDirectory() throws Exception {
+    void emptyDirectory() throws Exception {
         Logger logger = EasyMock.createNiceMock(Logger.class);
 
         ArtifactMetadata am = new ArtifactMetadata();
@@ -77,8 +77,8 @@ public class ArtifactVisitorTest {
         Files.walkFileTree(tempDir, visitor);
         EasyMock.verify(logger, mr);
 
-        assertTrue(Files.isSymbolicLink(jar1));
-        assertTrue(Files.isSymbolicLink(jar2));
-        assertTrue(Files.isRegularFile(jar3, LinkOption.NOFOLLOW_LINKS));
+        assertThat(jar1).isSymbolicLink();
+        assertThat(jar2).isSymbolicLink();
+        assertThat(Files.isRegularFile(jar3, LinkOption.NOFOLLOW_LINKS)).isTrue();
     }
 }


### PR DESCRIPTION
Replaced all JUnit assertions with AssertJ to improve test readability and maintainability. AssertJ provides a more expressive, fluent API and generates clearer failure messages, making debugging easier. This migration enhances consistency across tests and reduces boilerplate assertions.